### PR TITLE
update ci

### DIFF
--- a/.github/workflows/cyphal.yml
+++ b/.github/workflows/cyphal.yml
@@ -5,7 +5,7 @@ jobs:
     runs-on: ubuntu-22.04
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: recursive
           fetch-depth: 0
@@ -13,13 +13,16 @@ jobs:
       - name: Install dependencies
         run: ./scripts/tools/install_for_ubuntu.sh --yes
 
-      - name: Archive .bin file
+      - name: Build Cyphal binary
+        run: make cyphal
+
+      - name: Upload .bin file
         uses: actions/upload-artifact@v3
         with:
           name: cyphal_firmware.bin
           path: build/obj/example.bin
 
-      - name: Archive .elf file
+      - name: Upload .elf file
         uses: actions/upload-artifact@v3
         with:
           name: cyphal_firmware.elf
@@ -29,7 +32,7 @@ jobs:
     runs-on: ubuntu-22.04
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: recursive
           fetch-depth: 0

--- a/.github/workflows/dronecan.yml
+++ b/.github/workflows/dronecan.yml
@@ -5,11 +5,11 @@ jobs:
     runs-on: ubuntu-22.04
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: recursive
           fetch-depth: 0
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           repository: PonomarevDA/dronecan_application
           path: 'Libs/Dronecan'
@@ -23,15 +23,27 @@ jobs:
 
       - run: make dronecan
 
+      - name: Upload .bin file
+        uses: actions/upload-artifact@v3
+        with:
+          name: cyphal_firmware.bin
+          path: build/obj/example.bin
+
+      - name: Upload .elf file
+        uses: actions/upload-artifact@v3
+        with:
+          name: cyphal_firmware.elf
+          path: build/obj/example.elf
+
   sitl:
     runs-on: ubuntu-22.04
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: recursive
           fetch-depth: 0
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           repository: PonomarevDA/dronecan_application
           path: 'Libs/Dronecan'

--- a/.github/workflows/dronecan.yml
+++ b/.github/workflows/dronecan.yml
@@ -9,19 +9,12 @@ jobs:
         with:
           submodules: recursive
           fetch-depth: 0
-      - uses: actions/checkout@v4
-        with:
-          repository: PonomarevDA/dronecan_application
-          path: 'Libs/Dronecan'
-          token: ${{ secrets.DRONECAN_APPLICATION_TOKEN }}
-          fetch-depth: 0
-      - name: Checkout Dronecan
-        run: cd Libs/Dronecan && git checkout bb50fad # v0.3.1
 
       - name: Install dependencies
         run: ./scripts/tools/install_for_ubuntu.sh --yes
 
-      - run: make dronecan
+      - name: Build DroneCAN binary
+        run: make dronecan
 
       - name: Upload .bin file
         uses: actions/upload-artifact@v3

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -8,7 +8,7 @@ jobs:
     env:
       BUILD_WRAPPER_OUT_DIR: bw-output
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: recursive
           fetch-depth: 0

--- a/.gitmodules
+++ b/.gitmodules
@@ -10,3 +10,6 @@
 [submodule "Libs/stm32-cube-project"]
 	path = Libs/stm32-cube-project
 	url = https://github.com/RaccoonLabHardware/mini-v2-software.git
+[submodule "Libs/Dronecan"]
+	path = Libs/Dronecan
+	url = git@github.com:PonomarevDA/dronecan_application.git

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Code Smells](https://sonarcloud.io/api/project_badges/measure?project=RaccoonlabDev_mini_v2_node&metric=code_smells)](https://sonarcloud.io/summary/new_code?id=RaccoonlabDev_mini_v2_node) [![Lines of Code](https://sonarcloud.io/api/project_badges/measure?project=RaccoonlabDev_mini_v2_node&metric=ncloc)](https://sonarcloud.io/summary/new_code?id=RaccoonlabDev_mini_v2_node) [![cyphal](https://github.com/RaccoonlabDev/mini_v2_node/actions/workflows/cyphal.yml/badge.svg)](https://github.com/RaccoonlabDev/mini_v2_node/actions/workflows/cyphal.yml) [![dronecan](https://github.com/RaccoonlabDev/mini_v2_node/actions/workflows/dronecan.yml/badge.svg)](https://github.com/RaccoonlabDev/mini_v2_node/actions/workflows/dronecan.yml)
+
 # Mini v2 Cyphal/DroneCAN application template
 
 This repo introduces a simple ready-to-use Cyphal/DroneCAN application template for [RL Mini v2](https://docs.raccoonlab.co/guide/can_pwm/can_pwm_mini_v2.html) node.


### PR DESCRIPTION
- update actions/checkout@v3 to actions/checkout@v4
- add missed `make cyphal` in cyphal ci
- upload cyphal and dronecan artifacts
- add  public dronecan submodule instead of using a private one 
- add sonarcloud badges to readme