### PR TITLE
fix sonarcloud ci: do not trigger on PR

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -1,11 +1,5 @@
 name: SonarCloud
-on:
-  push:
-    branches:
-    - '*'
-  pull_request:
-    branches:
-    - '*'
+on: [push]
 
 jobs:
   build:

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -1,5 +1,8 @@
 name: SonarCloud
-on: [push]
+on:
+  push:
+    branches:
+      - main
 
 jobs:
   build:


### PR DESCRIPTION
sonarcloud CI requires token, so it doesn't work anyway