### PR TITLE
fix rawcommand bug

### DIFF
--- a/Src/dronecan_application/modules/PWMModule.cpp
+++ b/Src/dronecan_application/modules/PWMModule.cpp
@@ -21,12 +21,12 @@ PWMModule::PWMModule() {
     init();
 }
 
-PwmChannelInfo PWMModule::params[static_cast<uint8_t>(PwmPin::PWM_AMOUNT)] = {
+std::array<PwmChannelInfo, static_cast<uint8_t>(PwmPin::PWM_AMOUNT)> PWMModule::params = {{
     {.pin = PwmPin::PWM_1},  // PWM1
     {.pin = PwmPin::PWM_2},  // PWM2
     {.pin = PwmPin::PWM_3},  // PWM3
     {.pin = PwmPin::PWM_4},  // PWM4
-};
+}};
 
 PwmChannelsParamsNames
     PWMModule::params_names[static_cast<uint8_t>(PwmPin::PWM_AMOUNT)] = {

--- a/Src/dronecan_application/modules/PWMModule.hpp
+++ b/Src/dronecan_application/modules/PWMModule.hpp
@@ -45,7 +45,7 @@ class PWMModule {
 public:
     void spin_once();
     static PWMModule &get_instance();
-    static PwmChannelInfo params[static_cast<uint8_t>(PwmPin::PWM_AMOUNT)];
+    static std::array<PwmChannelInfo, static_cast<uint8_t>(PwmPin::PWM_AMOUNT)> params;
     static PwmChannelsParamsNames params_names[static_cast<uint8_t>(PwmPin::PWM_AMOUNT)];
     static ModuleStatus module_status;
 


### PR DESCRIPTION
RawCommand is applied to PWM pins even if their channels are greater than rawcommand size. It actually leads to access outside an array. In practice, a random value is applied to such PWM pins.

I configured pwm.1_ch = 0 and pwm.4_ch = 6 and send a RawCommand with size=4. Look at power_rating_pct.

Here is an example of configuration, command and feedback.

<img src="https://github.com/RaccoonlabDev/mini_v2_node/assets/36133264/915b59c8-b8f2-4d14-a5de-c052bd016269" alt="drawing" width="600"/>

This PR fixes the bug. 
