### PR TITLE
update mini v3 submodule

### DIFF
--- a/cmake/Toolchain-arm-none-eabi.cmake
+++ b/cmake/Toolchain-arm-none-eabi.cmake
@@ -29,5 +29,6 @@ set(CMAKE_EXE_LINKER_FLAGS "-mcpu=${TARGET_ARCHITECTURE} -mthumb -lc -lm -lnosys
 add_compile_definitions(
     USE_HAL_DRIVER
     ${CPU}
-    CYPHAL_NUM_OF_CAN_BUSES=1
+    CYPHAL_NUM_OF_CAN_BUSES=2
+    NUM_OF_CAN_BUSES=2
 )


### PR DESCRIPTION
Mini v3 node changes:
- add fdcan 2
- add tim4 for pwm1, pwm2, pwm3, pwm4
- add spi2 1MHz, software NSS signal

### Firmware image size difference

- dronecan_v3: 40300 -> 43976 (+3676)
- cyphal_v3: 47572 -> 51256 (+3684)

### Test coverage

- With mini v3 node
