### PR TITLE
add second CAN example

### DIFF
--- a/Src/modules/dronecan/canopen/CMakeLists.txt
+++ b/Src/modules/dronecan/canopen/CMakeLists.txt
@@ -1,0 +1,6 @@
+# Copyright (C) 2023 Dmitry Ponomarev <ponomarevda96@gmail.com>
+# Distributed under the terms of the GPL v3 license, available in the file LICENSE.
+
+list(APPEND APPLICATION_SOURCES
+    ${CMAKE_CURRENT_LIST_DIR}/canopen.cpp
+)

--- a/Src/modules/dronecan/canopen/canopen.cpp
+++ b/Src/modules/dronecan/canopen/canopen.cpp
@@ -1,0 +1,45 @@
+/**
+ * This program is free software under the GNU General Public License v3.
+ * See <https://www.gnu.org/licenses/> for details.
+ * Author: Dmitry Ponomarev <ponomarevda96@gmail.com>
+ */
+
+#include "canopen.hpp"
+#include "can_driver.h"
+#include "common/algorithms.hpp"
+
+REGISTER_MODULE(CanopenModule)
+
+void CanopenModule::init() {
+    health = Status::OK;
+
+    if (canDriverInit(1000000, CAN_DRIVER_SECOND) < 0) {
+        health = Status::FATAL_MALFANCTION;
+    }
+
+    if (raw_command_sub.init(raw_command_cb) < 0) {
+        health = Status::FATAL_MALFANCTION;
+    }
+
+    mode = Module::Mode::OPERATIONAL;
+}
+
+void CanopenModule::spin_once() {
+    // We probably want to check TTL here
+}
+
+void CanopenModule::raw_command_cb(const RawCommand_t& msg) {
+    if (msg.size < RAW_COMMAND_CHANNEL + 1) {
+        return;
+    }
+
+    auto raw_command_value = msg.raw_cmd[RAW_COMMAND_CHANNEL];
+    uint8_t setpoint_percent = mapFloat((float)raw_command_value, 0.0f, 8191, 0.0f, 100.0f);
+
+    CanardCANFrame frame;
+    frame.id = RAW_COMMAND_CHANNEL;
+    frame.data[0] = setpoint_percent;
+    frame.data_len = 1;
+
+    canDriverTransmit(&frame, CAN_DRIVER_SECOND);
+}

--- a/Src/modules/dronecan/canopen/canopen.hpp
+++ b/Src/modules/dronecan/canopen/canopen.hpp
@@ -1,0 +1,36 @@
+/**
+ * This program is free software under the GNU General Public License v3.
+ * See <https://www.gnu.org/licenses/> for details.
+ * Author: Dmitry Ponomarev <ponomarevda96@gmail.com>
+ */
+
+#ifndef SRC_MODULES_CANOPEN_HPP_
+#define SRC_MODULES_CANOPEN_HPP_
+
+#include "module.hpp"
+#include "subscriber.hpp"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+class CanopenModule : public Module {
+public:
+    CanopenModule() : Module(10.0) {}
+    void init() override;
+
+protected:
+    void spin_once() override;
+
+private:
+    static void raw_command_cb(const RawCommand_t& msg);
+    static inline DronecanSubscriber<RawCommand_t> raw_command_sub;
+
+    static constexpr uint8_t RAW_COMMAND_CHANNEL = 0;
+};
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // SRC_MODULES_CANOPEN_HPP_


### PR DESCRIPTION
This PR adds an example of how can you can use DroneCAN one CAN1 and another CAN protocol on CAN2 on mini v3 node.

In this example:
- The node subscribes to RawCommand channel 0 on CAN1
- Each time it receives a RawCommand, it converts the int16 value to percent and sends a single-byte CAN message to CAN2

To enable this module, you need to:
1. Add  `include(${SRC_DIR}/modules/dronecan/canopen/CMakeLists.txt)` to `Src/applications/dronecan/CMakeLists.txt` file.
2. Build and upload the firmware with `make dronecan_v3 upload`

You may need to add DroneCAN or Cyphal subscriber depending on your logic.

### Test coverage

I connected a Mini v3 CAN1 (DroneCAN) and CAN2 (custom CAN protocol) to a RL CAN-sniffer. In gui tool I saw a message:

![image](https://github.com/user-attachments/assets/2746a072-0478-4ce6-919b-a157138be467)

### Context

- The feature was requested in: https://github.com/RaccoonlabDev/mini_v2_node/issues/50