### PR TITLE
add pwm1-4 to mini-v3

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,16 +1,8 @@
-Describe the solver problem.
-
-Describe the solution:
-- Add...
-- Fix...
-- Refactor...
+This PR adds/fixes/refactors ...
 
 ### Firmware image size difference
 
-<!--
-At the moment we don't automatically evaluate the firmware size difference.
-Please, evaluate it manually.
--->
+<!-- We don't automatically evaluate the firmware size difference yet. Please, do it manually. -->
 
 - dronecan_v2: ? -> ? (+?)
 - dronecan_v3: ? -> ? (+?)

--- a/Src/platform/stm32/pwm/pwm.cpp
+++ b/Src/platform/stm32/pwm/pwm.cpp
@@ -1,0 +1,60 @@
+/**
+ * This program is free software under the GNU General Public License v3.
+ * See <https://www.gnu.org/licenses/> for details.
+ * Author: Dmitry Ponomarev <ponomarevda96@gmail.com>
+ */
+
+#include "pwm.hpp"
+
+extern TIM_HandleTypeDef htim4;
+
+namespace HAL {
+
+int8_t Pwm::init(PwmPin pwm_pin) {
+    if (pwm_pin > PwmPin::PWM_AMOUNT) {
+        return -1;
+    }
+
+    auto& pwm = pwms[static_cast<uint8_t>(pwm_pin)];
+    return HAL_OK == HAL_TIM_PWM_Start(&pwm.htim, pwm.channel) ? 0 : -1;
+}
+
+void Pwm::set_duration(const PwmPin pwm_pin, uint32_t duration_us) {
+    if (pwm_pin > PwmPin::PWM_AMOUNT) {
+        return;
+    }
+
+    pwms[static_cast<uint8_t>(pwm_pin)].ccr = duration_us;
+}
+
+uint32_t Pwm::get_duration(PwmPin pwm_pin) {
+    if (pwm_pin > PwmPin::PWM_AMOUNT) {
+        return 0;
+    }
+
+    return pwms[static_cast<uint8_t>(pwm_pin)].ccr;
+}
+
+void Pwm::set_frequency(PwmPin pwm_pin, uint32_t frequency_hz) {
+    if (pwm_pin > PwmPin::PWM_AMOUNT) {
+        return;
+    }
+
+    auto& pwm = pwms[static_cast<uint8_t>(pwm_pin)];
+    volatile uint32_t* arr_reg = &(pwm.htim.Instance->ARR);
+    uint16_t period_us = 1000000 / frequency_hz;
+    *arr_reg = period_us;
+}
+
+uint32_t Pwm::get_frequency(PwmPin pwm_pin) {
+    if (pwm_pin > PwmPin::PWM_AMOUNT) {
+        return -1;
+    }
+
+    auto& pwm = pwms[static_cast<uint8_t>(pwm_pin)];
+    volatile uint32_t* arr_reg = &(pwm.htim.Instance->ARR);
+    uint32_t frequency = 1000000 / *arr_reg;
+    return frequency;
+}
+
+}  // namespace HAL

--- a/Src/platform/stm32/pwm/pwm.hpp
+++ b/Src/platform/stm32/pwm/pwm.hpp
@@ -1,0 +1,27 @@
+/**
+ * This program is free software under the GNU General Public License v3.
+ * See <https://www.gnu.org/licenses/> for details.
+ * Author: Dmitry Ponomarev <ponomarevda96@gmail.com>
+ */
+
+#ifndef SRC_PLATFORM_STM32_PWM_HPP_
+#define SRC_PLATFORM_STM32_PWM_HPP_
+
+#include <stdint.h>
+#include <array>
+#include "periphery/pwm/pwm.hpp"
+#include "main.h"
+
+namespace HAL {
+
+struct PwmPinInfo {
+    TIM_HandleTypeDef& htim;
+    uint32_t channel;
+    volatile uint32_t& ccr;
+};
+
+extern const std::array<PwmPinInfo, static_cast<uint8_t>(PwmPin::PWM_AMOUNT)> pwms;
+
+}  // namespace HAL
+
+#endif  // SRC_PLATFORM_STM32_PWM_HPP_

--- a/Src/platform/stm32f103/CMakeLists.txt
+++ b/Src/platform/stm32f103/CMakeLists.txt
@@ -11,6 +11,7 @@ add_executable(${EXECUTABLE}
 
     ${ROOT_DIR}/Src/periphery/adc/circuit_periphery.cpp
     ${CMAKE_CURRENT_LIST_DIR}/adc.cpp
+    ${ROOT_DIR}/Src/platform/stm32/pwm/pwm.cpp
     ${CMAKE_CURRENT_LIST_DIR}/pwm.cpp
     ${CMAKE_CURRENT_LIST_DIR}/iwdg.cpp
     ${CMAKE_CURRENT_LIST_DIR}/led.cpp

--- a/Src/platform/stm32f103/pwm.cpp
+++ b/Src/platform/stm32f103/pwm.cpp
@@ -5,71 +5,18 @@
  */
 
 #include "periphery/pwm/pwm.hpp"
-#include "main.h"
+#include "platform/stm32/pwm/pwm.hpp"
 
 extern TIM_HandleTypeDef htim3;
 extern TIM_HandleTypeDef htim4;
 
 namespace HAL {
 
-struct PwmPinInfo {
-    TIM_HandleTypeDef& htim;
-    uint32_t channel;
-    volatile uint32_t& ccr;
-};
-
-static const PwmPinInfo info[static_cast<uint8_t>(PwmPin::PWM_AMOUNT)] = {
+const std::array<PwmPinInfo, static_cast<uint8_t>(PwmPin::PWM_AMOUNT)> pwms = {{
     {.htim = htim4,     .channel = TIM_CHANNEL_2,   .ccr = TIM4->CCR2},     // PB7
     {.htim = htim4,     .channel = TIM_CHANNEL_1,   .ccr = TIM4->CCR1},     // PB6
     {.htim = htim3,     .channel = TIM_CHANNEL_1,   .ccr = TIM3->CCR1},     // PB4
     {.htim = htim3,     .channel = TIM_CHANNEL_2,   .ccr = TIM3->CCR2},     // PB5
-};
-
-int8_t Pwm::init(PwmPin pwm_pin) {
-    if (pwm_pin > PwmPin::PWM_AMOUNT) {
-        return -1;
-    }
-
-    auto& pwm_pin_info = info[static_cast<uint8_t>(pwm_pin)];
-    return HAL_OK == HAL_TIM_PWM_Start(&pwm_pin_info.htim, pwm_pin_info.channel) ? 0 : -1;
-}
-
-void Pwm::set_duration(const PwmPin pwm_pin, uint32_t duration_us) {
-    if (pwm_pin > PwmPin::PWM_AMOUNT) {
-        return;
-    }
-
-    info[static_cast<uint8_t>(pwm_pin)].ccr = duration_us;
-}
-
-uint32_t Pwm::get_duration(PwmPin pwm_pin) {
-    if (pwm_pin > PwmPin::PWM_AMOUNT) {
-        return 0;
-    }
-
-    return info[static_cast<uint8_t>(pwm_pin)].ccr;
-}
-
-void Pwm::set_frequency(PwmPin pwm_pin, uint32_t frequency_hz) {
-    if (pwm_pin > PwmPin::PWM_AMOUNT) {
-        return;
-    }
-
-    auto& pwm_pin_info = info[static_cast<uint8_t>(pwm_pin)];
-    volatile uint32_t* arr_reg = &(pwm_pin_info.htim.Instance->ARR);
-    uint16_t period_us = 1000000 / frequency_hz;
-    *arr_reg = period_us;
-}
-
-uint32_t Pwm::get_frequency(PwmPin pwm_pin) {
-    if (pwm_pin > PwmPin::PWM_AMOUNT) {
-        return -1;
-    }
-
-    auto& pwm_pin_info = info[static_cast<uint8_t>(pwm_pin)];
-    volatile uint32_t* arr_reg = &(pwm_pin_info.htim.Instance->ARR);
-    uint32_t frequency = 1000000 / *arr_reg;
-    return frequency;
-}
+}};
 
 }  // namespace HAL

--- a/Src/platform/stm32g0b1/CMakeLists.txt
+++ b/Src/platform/stm32g0b1/CMakeLists.txt
@@ -15,6 +15,7 @@ add_executable(${EXECUTABLE}
     ${ROOT_DIR}/Src/common/module.cpp
 
     ${ROOT_DIR}/Src/periphery/adc/circuit_periphery.cpp
+    ${ROOT_DIR}/Src/platform/stm32/pwm/pwm.cpp
     ${PLATFORM_DIR}/stm32f103/adc.cpp
     ${PLATFORM_DIR}/stm32g0b1/pwm.cpp
     ${PLATFORM_DIR}/stm32f103/iwdg.cpp

--- a/Src/platform/stm32g0b1/CMakeLists.txt
+++ b/Src/platform/stm32g0b1/CMakeLists.txt
@@ -16,7 +16,7 @@ add_executable(${EXECUTABLE}
 
     ${ROOT_DIR}/Src/periphery/adc/circuit_periphery.cpp
     ${PLATFORM_DIR}/stm32f103/adc.cpp
-    ${PLATFORM_DIR}/ubuntu/pwm.cpp
+    ${PLATFORM_DIR}/stm32g0b1/pwm.cpp
     ${PLATFORM_DIR}/stm32f103/iwdg.cpp
     ${PLATFORM_DIR}/stm32f103/led.cpp
     ${PLATFORM_DIR}/stm32f103/temperature_sensor.cpp

--- a/Src/platform/stm32g0b1/pwm.cpp
+++ b/Src/platform/stm32g0b1/pwm.cpp
@@ -1,0 +1,74 @@
+/**
+ * This program is free software under the GNU General Public License v3.
+ * See <https://www.gnu.org/licenses/> for details.
+ * Author: Dmitry Ponomarev <ponomarevda96@gmail.com>
+ */
+
+#include "periphery/pwm/pwm.hpp"
+#include "main.h"
+
+extern TIM_HandleTypeDef htim4;
+
+namespace HAL {
+
+struct PwmPinInfo {
+    TIM_HandleTypeDef& htim;
+    uint32_t channel;
+    volatile uint32_t& ccr;
+};
+
+static const PwmPinInfo info[static_cast<uint8_t>(PwmPin::PWM_AMOUNT)] = {
+    {.htim = htim4,     .channel = TIM_CHANNEL_2,   .ccr = TIM4->CCR2},     // PB7
+    {.htim = htim4,     .channel = TIM_CHANNEL_1,   .ccr = TIM4->CCR1},     // PB6
+    {.htim = htim4,     .channel = TIM_CHANNEL_4,   .ccr = TIM3->CCR4},     // PB9
+    {.htim = htim4,     .channel = TIM_CHANNEL_3,   .ccr = TIM3->CCR3},     // PB8
+};
+
+int8_t Pwm::init(PwmPin pwm_pin) {
+    if (pwm_pin > PwmPin::PWM_AMOUNT) {
+        return -1;
+    }
+
+    auto& pwm_pin_info = info[static_cast<uint8_t>(pwm_pin)];
+    return HAL_OK == HAL_TIM_PWM_Start(&pwm_pin_info.htim, pwm_pin_info.channel) ? 0 : -1;
+}
+
+void Pwm::set_duration(const PwmPin pwm_pin, uint32_t duration_us) {
+    if (pwm_pin > PwmPin::PWM_AMOUNT) {
+        return;
+    }
+
+    info[static_cast<uint8_t>(pwm_pin)].ccr = duration_us;
+}
+
+uint32_t Pwm::get_duration(PwmPin pwm_pin) {
+    if (pwm_pin > PwmPin::PWM_AMOUNT) {
+        return 0;
+    }
+
+    return info[static_cast<uint8_t>(pwm_pin)].ccr;
+}
+
+void Pwm::set_frequency(PwmPin pwm_pin, uint32_t frequency_hz) {
+    if (pwm_pin > PwmPin::PWM_AMOUNT) {
+        return;
+    }
+
+    auto& pwm_pin_info = info[static_cast<uint8_t>(pwm_pin)];
+    volatile uint32_t* arr_reg = &(pwm_pin_info.htim.Instance->ARR);
+    uint16_t period_us = 1000000 / frequency_hz;
+    *arr_reg = period_us;
+}
+
+uint32_t Pwm::get_frequency(PwmPin pwm_pin) {
+    if (pwm_pin > PwmPin::PWM_AMOUNT) {
+        return -1;
+    }
+
+    auto& pwm_pin_info = info[static_cast<uint8_t>(pwm_pin)];
+    volatile uint32_t* arr_reg = &(pwm_pin_info.htim.Instance->ARR);
+    uint32_t frequency = 1000000 / *arr_reg;
+    return frequency;
+}
+
+}  // namespace HAL

--- a/Src/platform/stm32g0b1/pwm.cpp
+++ b/Src/platform/stm32g0b1/pwm.cpp
@@ -5,70 +5,18 @@
  */
 
 #include "periphery/pwm/pwm.hpp"
-#include "main.h"
+#include "platform/stm32/pwm/pwm.hpp"
 
 extern TIM_HandleTypeDef htim4;
 
+
 namespace HAL {
 
-struct PwmPinInfo {
-    TIM_HandleTypeDef& htim;
-    uint32_t channel;
-    volatile uint32_t& ccr;
-};
-
-static const PwmPinInfo info[static_cast<uint8_t>(PwmPin::PWM_AMOUNT)] = {
+const std::array<PwmPinInfo, static_cast<uint8_t>(PwmPin::PWM_AMOUNT)> pwms = {{
     {.htim = htim4,     .channel = TIM_CHANNEL_2,   .ccr = TIM4->CCR2},     // PB7
     {.htim = htim4,     .channel = TIM_CHANNEL_1,   .ccr = TIM4->CCR1},     // PB6
     {.htim = htim4,     .channel = TIM_CHANNEL_4,   .ccr = TIM3->CCR4},     // PB9
     {.htim = htim4,     .channel = TIM_CHANNEL_3,   .ccr = TIM3->CCR3},     // PB8
-};
-
-int8_t Pwm::init(PwmPin pwm_pin) {
-    if (pwm_pin > PwmPin::PWM_AMOUNT) {
-        return -1;
-    }
-
-    auto& pwm_pin_info = info[static_cast<uint8_t>(pwm_pin)];
-    return HAL_OK == HAL_TIM_PWM_Start(&pwm_pin_info.htim, pwm_pin_info.channel) ? 0 : -1;
-}
-
-void Pwm::set_duration(const PwmPin pwm_pin, uint32_t duration_us) {
-    if (pwm_pin > PwmPin::PWM_AMOUNT) {
-        return;
-    }
-
-    info[static_cast<uint8_t>(pwm_pin)].ccr = duration_us;
-}
-
-uint32_t Pwm::get_duration(PwmPin pwm_pin) {
-    if (pwm_pin > PwmPin::PWM_AMOUNT) {
-        return 0;
-    }
-
-    return info[static_cast<uint8_t>(pwm_pin)].ccr;
-}
-
-void Pwm::set_frequency(PwmPin pwm_pin, uint32_t frequency_hz) {
-    if (pwm_pin > PwmPin::PWM_AMOUNT) {
-        return;
-    }
-
-    auto& pwm_pin_info = info[static_cast<uint8_t>(pwm_pin)];
-    volatile uint32_t* arr_reg = &(pwm_pin_info.htim.Instance->ARR);
-    uint16_t period_us = 1000000 / frequency_hz;
-    *arr_reg = period_us;
-}
-
-uint32_t Pwm::get_frequency(PwmPin pwm_pin) {
-    if (pwm_pin > PwmPin::PWM_AMOUNT) {
-        return -1;
-    }
-
-    auto& pwm_pin_info = info[static_cast<uint8_t>(pwm_pin)];
-    volatile uint32_t* arr_reg = &(pwm_pin_info.htim.Instance->ARR);
-    uint32_t frequency = 1000000 / *arr_reg;
-    return frequency;
-}
+}};
 
 }  // namespace HAL


### PR DESCRIPTION
This PR adds PWM1-4 to mini-v3 node.

### Firmware image size difference

- dronecan_v2: 37568 ->37568 (+0)
- dronecan_v3: 43976 ->44440 (+464)
- cyphal_v2: 39872 -> 39872 (+0)
- cyphal_v3: 51256 -> 51660 (+404)

### Test coverage

- mini v2 and mini v3 nodes control a servo with PWM1 and PWM2
