### PR TITLE
refactor dronecan pwm feedback and crct

### DIFF
--- a/Src/applications/dronecan/CMakeLists.txt
+++ b/Src/applications/dronecan/CMakeLists.txt
@@ -8,8 +8,9 @@ cmake_path(GET APPLICATIONS_DIR PARENT_PATH SRC_DIR)
 add_definitions(-DCONFIG_USE_DRONECAN=1)
 
 include(${SRC_DIR}/modules/dronecan/core/CMakeLists.txt)
-include(${SRC_DIR}/modules/circuit_status/dronecan/CMakeLists.txt)
 include(${SRC_DIR}/modules/dronecan/arming/CMakeLists.txt)
+include(${SRC_DIR}/modules/circuit_status/dronecan/CMakeLists.txt)
+include(${SRC_DIR}/modules/dronecan/feedback/CMakeLists.txt)
 include(${SRC_DIR}/modules/dronecan/pwm/CMakeLists.txt)
 
 if(USE_PLATFORM_NODE_V3)

--- a/Src/modules/circuit_status/dronecan/CMakeLists.txt
+++ b/Src/modules/circuit_status/dronecan/CMakeLists.txt
@@ -4,3 +4,7 @@
 list(APPEND APPLICATION_SOURCES
     ${CMAKE_CURRENT_LIST_DIR}/circuit_status.cpp
 )
+
+list(APPEND LIBPARAMS_PARAMS
+    ${CMAKE_CURRENT_LIST_DIR}/params.yaml
+)

--- a/Src/modules/circuit_status/dronecan/circuit_status.hpp
+++ b/Src/modules/circuit_status/dronecan/circuit_status.hpp
@@ -13,15 +13,28 @@
 
 class DronecanCircuitStatus : public Module {
 public:
+    enum class Bitmask : uint8_t {
+        DISABLED                    = 0,
+        ENABLE_DEV_TEMPERATURE_PUB  = 1,
+        ENABLE_5V_PUB               = 2,
+        ENABLE_VIN_PUB              = 4,
+        ENABLE_HW_CHECKS            = 8,
+        ENABLE_ALL_BY_DEFAULT       = 15,
+    };
+
     DronecanCircuitStatus() : Module(2.0f, Protocol::DRONECAN) {}
     void init() override;
 
 protected:
+    void update_params() override;
     void spin_once() override;
 
 private:
     DronecanPublisher<CircuitStatus_t> circuit_status;
     DronecanPublisher<Temperature_t> dev_temperature;
+
+    uint8_t node_id{0};
+    uint8_t bitmask{0};
 };
 
 #endif  // SRC_MODULES_CIRCUIT_STATUS_DRONECAN_CIRCUIT_STATUS_HPP_

--- a/Src/modules/circuit_status/dronecan/params.yaml
+++ b/Src/modules/circuit_status/dronecan/params.yaml
@@ -1,0 +1,14 @@
+crct.bitmask:
+  type: Integer
+  note:
+    "Bit mask to enable CircuitStatus features:
+    </br> Bit 1 - enable dev.Temperature with device_id=NODE_ID,
+    </br> Bit 2 - enable 5v publisher,
+    </br> Bit 3 - enable Vin publisher.
+    </br> Bit 4 - enable overvoltage, undervoltage, overcurrent and overheat checks.
+    </br> By default 15 that mean enable all publishers"
+  enum: PARAM_CRCT_BITMASK
+  flags: mutable
+  default: 15
+  min: 0
+  max: 15

--- a/Src/modules/dronecan/feedback/CMakeLists.txt
+++ b/Src/modules/dronecan/feedback/CMakeLists.txt
@@ -1,0 +1,10 @@
+# Copyright (C) 2023 Dmitry Ponomarev <ponomarevda96@gmail.com>
+# Distributed under the terms of the GPL v3 license, available in the file LICENSE.
+
+list(APPEND APPLICATION_SOURCES
+    ${CMAKE_CURRENT_LIST_DIR}/feedback.cpp
+)
+
+list(APPEND LIBPARAMS_PARAMS
+    ${CMAKE_CURRENT_LIST_DIR}/params.yaml
+)

--- a/Src/modules/dronecan/feedback/feedback.cpp
+++ b/Src/modules/dronecan/feedback/feedback.cpp
@@ -1,0 +1,110 @@
+/**
+ * This program is free software under the GNU General Public License v3.
+ * See <https://www.gnu.org/licenses/> for details.
+ * Author: Dmitry Ponomarev <ponomarevda96@gmail.com>
+ * Author: Anastasiia Stepanova <asiiapine@gmail.com>
+ */
+
+#include "feedback.hpp"
+#include "peripheral/adc/circuit_periphery.hpp"
+
+
+REGISTER_MODULE(FeedbackModule)
+
+
+void FeedbackModule::init() {
+    mode = Module::Mode::STANDBY;
+}
+
+void FeedbackModule::update_params() {
+    auto cmd_type_value = paramsGetIntegerValue(IntParamsIndexes::PARAM_PWM_CMD_TYPE);
+    cmd_type = static_cast<CommandType>(cmd_type_value);
+
+    auto feedback_type_value = paramsGetIntegerValue(IntParamsIndexes::PARAM_FEEDBACK_TYPE);
+    feedback_type = static_cast<FeedbackType>(feedback_type_value);
+
+    switch (feedback_type) {
+        case FeedbackType::DEFAULT_1_HZ:
+            period_ms = 1000;
+            break;
+        case FeedbackType::DEFAULT_10_HZ:
+            period_ms = 100;
+            break;
+        default:
+            period_ms = 1000;
+            break;
+    }
+}
+
+void FeedbackModule::spin_once() {
+    if (feedback_type == FeedbackType::DISABLED) {
+        return;
+    }
+
+    for (auto& pwm : PWMModule::params) {
+        if (pwm.channel < 0) {
+            continue;
+        }
+
+        switch (cmd_type) {
+            case CommandType::RAW_COMMAND:
+                publish_esc_status(pwm);
+                break;
+            case CommandType::ARRAY_COMMAND:
+                publish_actuator_status(pwm);
+                break;
+            case CommandType::HARDPOINT_COMMAND:
+                publish_hardpoint_status(pwm);
+                break;
+            default:
+                break;
+        }
+    }
+}
+
+void FeedbackModule::publish_esc_status(PwmChannelInfo& pwm) {
+    esc_status.msg = {
+        .error_count = esc_status.msg.error_count + 1,
+        .voltage = CircuitPeriphery::voltage_vin(),
+        .current = CircuitPeriphery::current(),
+        .temperature = static_cast<float>(CircuitPeriphery::temperature()),
+        .rpm = 0,
+        .power_rating_pct = HAL::Pwm::get_percent(pwm.pin, pwm.min, pwm.max),
+        .esc_index = static_cast<uint8_t>(pwm.channel),
+    };
+
+    esc_status.publish();
+}
+
+void FeedbackModule::publish_actuator_status(PwmChannelInfo& pwm) {
+    actuator_status.msg = {
+        .actuator_id = static_cast<uint8_t>(pwm.channel),
+
+        // The following fields are not used in PX4 anyway
+        // Let's fill them with something useful for logging for a while
+        .position = CircuitPeriphery::voltage_5v(),
+        .force = CircuitPeriphery::current(),
+        .speed = static_cast<float>(CircuitPeriphery::temperature()),
+
+        .reserved = 0,
+        .power_rating_pct = HAL::Pwm::get_percent(pwm.pin, pwm.min, pwm.max),
+    };
+
+    actuator_status.publish();
+}
+
+void FeedbackModule::publish_hardpoint_status(PwmChannelInfo& pwm) {
+    static constexpr uint16_t CMD_RELEASE_OR_MIN = 0;
+    static constexpr uint16_t CMD_HOLD_OR_MAX = 1;
+
+    auto pwm_duration_us = HAL::Pwm::get_duration(pwm.pin);
+
+    hardpoint_status.msg = {
+        .hardpoint_id = static_cast<uint8_t>(pwm.channel),
+        .payload_weight = 0.0f,
+        .payload_weight_variance = 0.0f,
+        .status = (pwm_duration_us == pwm.min) ? CMD_RELEASE_OR_MIN : CMD_HOLD_OR_MAX,
+    };
+
+    hardpoint_status.publish();
+}

--- a/Src/modules/dronecan/feedback/feedback.hpp
+++ b/Src/modules/dronecan/feedback/feedback.hpp
@@ -1,0 +1,51 @@
+/**
+ * This program is free software under the GNU General Public License v3.
+ * See <https://www.gnu.org/licenses/> for details.
+ * Author: Dmitry Ponomarev <ponomarevda96@gmail.com>
+ * Author: Anastasiia Stepanova <asiiapine@gmail.com>
+ */
+
+#ifndef SRC_MODULES_FEEDBACK_HPP_
+#define SRC_MODULES_FEEDBACK_HPP_
+
+#include "common/module.hpp"
+#include "peripheral/pwm/pwm.hpp"
+
+#include "dronecan.h"
+#include "logger.hpp"
+#include "publisher.hpp"
+#include "subscriber.hpp"
+
+#include "modules/dronecan/pwm/PWMModule.hpp"
+
+enum class FeedbackType: uint8_t {
+    DISABLED,
+    DEFAULT_1_HZ,
+    DEFAULT_10_HZ,
+
+    NUMBER_OF_FEEDBACKS,
+};
+
+class FeedbackModule : public Module {
+public:
+    void init() override;
+
+    inline FeedbackModule() : Module(10, Protocol::DRONECAN) {}
+
+protected:
+    void spin_once() override;
+    void update_params() override;
+
+    void publish_esc_status(PwmChannelInfo& pwm);
+    void publish_actuator_status(PwmChannelInfo& pwm);
+    void publish_hardpoint_status(PwmChannelInfo& pwm);
+    
+    static inline DronecanPublisher<ActuatorStatus_t> actuator_status;
+    static inline DronecanPublisher<EscStatus_t> esc_status;
+    static inline DronecanPublisher<HardpointStatus> hardpoint_status;
+
+    CommandType cmd_type;
+    FeedbackType feedback_type;
+};
+
+#endif  // SRC_MODULES_FEEDBACK_HPP_

--- a/Src/modules/dronecan/feedback/params.yaml
+++ b/Src/modules/dronecan/feedback/params.yaml
@@ -1,0 +1,8 @@
+feedback.type:
+  type: Integer
+  note: Indicates the operational mode of the node. 0 means disabled. When set to 1, the command of corresponding Status type for cmd_type will be transmitted (esc.RawCommand - esc.Status, actuator.ArrayCommand - actuator.Status) with frequency 1 Hz. When set to 2 - 10 Hz. 
+  enum: PARAM_FEEDBACK_TYPE
+  flags: mutable
+  default: 0
+  min: 0
+  max: 2

--- a/Src/modules/dronecan/pwm/PWMModule.hpp
+++ b/Src/modules/dronecan/pwm/PWMModule.hpp
@@ -32,7 +32,6 @@ struct PwmChannelsParamsNames {
     uint8_t max;
     uint8_t def;
     uint8_t ch;
-    uint8_t fb;
 };
 
 struct PwmChannelInfo {
@@ -44,8 +43,6 @@ struct PwmChannelInfo {
     int16_t     channel{-1};
     uint16_t    command_val{0};
     uint32_t    cmd_end_time_ms{0};
-    uint32_t    next_status_pub_ms{0};
-    uint8_t     fb{0};
     bool        is_engaged{false};
 };
 
@@ -55,11 +52,12 @@ public:
 
     inline PWMModule() : Module(50, Protocol::DRONECAN) {}
 
+    static std::array<PwmChannelInfo, static_cast<uint8_t>(HAL::PwmPin::PWM_AMOUNT)> params;
+
 protected:
     void update_params() override;
     void spin_once() override;
 
-    static std::array<PwmChannelInfo, static_cast<uint8_t>(HAL::PwmPin::PWM_AMOUNT)> params;
 
 private:
     void (*callback)(CanardRxTransfer*) = {};
@@ -73,17 +71,7 @@ private:
     static void hardpoint_callback(CanardRxTransfer* transfer);
     static void arming_status_callback(const ArmingStatus& msg);
 
-    static void publish_esc_status();
-    static void publish_actuator_status();
-    static void publish_raw_command();
-    static void publish_array_command();
-    static void publish_hardpoint_status();
-
     static inline DronecanSubscriber<RawCommand_t> raw_command_sub;
-
-    static inline DronecanPublisher<ActuatorStatus_t> actuator_status_pub;
-    static inline DronecanPublisher<EscStatus_t> esc_status_pub;
-    static inline DronecanPublisher<HardpointStatus> hardpoint_status_pub;
 
     static uint16_t pwm_freq;
     static CommandType pwm_cmd_type;

--- a/Src/modules/dronecan/pwm/params.yaml
+++ b/Src/modules/dronecan/pwm/params.yaml
@@ -25,7 +25,7 @@ pwm.cmd_type:
   min: 0
   max: 2
 
-pwm.1_ch:
+pwm1.ch:
   type: Integer
   note: Index of setpoint channel. [-1; 255]. -1 means disabled, # -2 means GPIO SET.
   enum: PARAM_PWM_1_CH
@@ -34,7 +34,7 @@ pwm.1_ch:
   min: -1
   max: 255
 
-pwm.1_min:
+pwm1.min:
   type: Integer
   note: PWM duration when setpoint is min (RawCommand is 0 or Command is -1.0)
   enum: PARAM_PWM_1_MIN
@@ -43,7 +43,7 @@ pwm.1_min:
   min: 1000
   max: 2000
 
-pwm.1_max:
+pwm1.max:
   type: Integer
   note: PWM duration when setpoint is max (RawCommand is 8191 or Command is 1.0)
   enum: PARAM_PWM_1_MAX
@@ -52,7 +52,7 @@ pwm.1_max:
   min: 1000
   max: 2000
 
-pwm.1_def:
+pwm1.def:
   type: Integer
   note: PWM duration when setpoint is negative or there is no setpoint at all.
   enum: PARAM_PWM_1_DEF
@@ -61,7 +61,7 @@ pwm.1_def:
   min: 1000
   max: 2000
 
-pwm.2_ch:
+pwm2.ch:
   type: Integer
   note: Index of setpoint channel. [-1; 255]. -1 means disabled, # -2 means GPIO SET.
   enum: PARAM_PWM_2_CH
@@ -70,7 +70,7 @@ pwm.2_ch:
   min: -1
   max: 255
 
-pwm.2_min:
+pwm2.min:
   type: Integer
   note: PWM duration when setpoint is min (RawCommand is 0 or Command is -1.0)
   enum: PARAM_PWM_2_MIN
@@ -79,7 +79,7 @@ pwm.2_min:
   min: 1000
   max: 2000
 
-pwm.2_max:
+pwm2.max:
   type: Integer
   note: PWM duration when setpoint is max (RawCommand is 8191 or Command is 1.0)
   enum: PARAM_PWM_2_MAX
@@ -88,7 +88,7 @@ pwm.2_max:
   min: 1000
   max: 2000
 
-pwm.2_def:
+pwm2.def:
   type: Integer
   note: PWM duration when setpoint is negative or there is no setpoint at all.
   enum: PARAM_PWM_2_DEF
@@ -97,7 +97,7 @@ pwm.2_def:
   min: 1000
   max: 2000
 
-pwm.3_ch:
+pwm3.ch:
   type: Integer
   note: Index of setpoint channel. [-1; 255]. -1 means disabled, # -2 means GPIO SET.
   enum: PARAM_PWM_3_CH
@@ -106,7 +106,7 @@ pwm.3_ch:
   min: -1
   max: 255
 
-pwm.3_min:
+pwm3.min:
   type: Integer
   note: PWM duration when setpoint is min (RawCommand is 0 or Command is -1.0)
   enum: PARAM_PWM_3_MIN
@@ -115,7 +115,7 @@ pwm.3_min:
   min: 1000
   max: 2000
 
-pwm.3_max:
+pwm3.max:
   type: Integer
   note: PWM duration when setpoint is max (RawCommand is 8191 or Command is 1.0)
   enum: PARAM_PWM_3_MAX
@@ -124,7 +124,7 @@ pwm.3_max:
   min: 1000
   max: 2000
 
-pwm.3_def:
+pwm3.def:
   type: Integer
   note: PWM duration when setpoint is negative or there is no setpoint at all.
   enum: PARAM_PWM_3_DEF
@@ -133,7 +133,7 @@ pwm.3_def:
   min: 1000
   max: 2000
 
-pwm.4_ch:
+pwm4.ch:
   type: Integer
   note: Index of setpoint channel. [-1; 255]. -1 means disabled, # -2 means GPIO SET.
   enum: PARAM_PWM_4_CH
@@ -142,7 +142,7 @@ pwm.4_ch:
   min: -1
   max: 255
 
-pwm.4_min:
+pwm4.min:
   type: Integer
   note: PWM duration when setpoint is min (RawCommand is 0 or Command is -1.0)
   enum: PARAM_PWM_4_MIN
@@ -151,7 +151,7 @@ pwm.4_min:
   min: 1000
   max: 2000
 
-pwm.4_max:
+pwm4.max:
   type: Integer
   note: PWM duration when setpoint is max (RawCommand is 8191 or Command is 1.0)
   enum: PARAM_PWM_4_MAX
@@ -160,7 +160,7 @@ pwm.4_max:
   min: 1000
   max: 2000
 
-pwm.4_def:
+pwm4.def:
   type: Integer
   note: PWM duration when setpoint is negative or there is no setpoint at all.
   enum: PARAM_PWM_4_DEF

--- a/Src/modules/dronecan/pwm/params.yaml
+++ b/Src/modules/dronecan/pwm/params.yaml
@@ -61,15 +61,6 @@ pwm.1_def:
   min: 1000
   max: 2000
 
-pwm.1_feedback:
-  type: Integer
-  note: Indicates the operational mode of the node. 0 means disabled. When set to 1, the command of corresponding Status type for cmd_type will be transmitted (esc.RawCommand - esc.Status, actuator.ArrayCommand - actuator.Status) with frequency 1 Hz. When set to 2 - 10 Hz. 
-  enum: PARAM_PWM_1_FB
-  flags: mutable
-  default: 0
-  min: 0
-  max: 2
-
 pwm.2_ch:
   type: Integer
   note: Index of setpoint channel. [-1; 255]. -1 means disabled, # -2 means GPIO SET.
@@ -105,15 +96,6 @@ pwm.2_def:
   default: 1000
   min: 1000
   max: 2000
-
-pwm.2_feedback:
-  type: Integer
-  note: Indicates the operational mode of the node. 0 means disabled. When set to 1, the command of corresponding Status type for cmd_type will be transmitted (esc.RawCommand - esc.Status, actuator.ArrayCommand - actuator.Status) with frequency 1 Hz. When set to 2 - 10 Hz. 
-  enum: PARAM_PWM_2_FB
-  flags: mutable
-  default: 0
-  min: 0
-  max: 2
 
 pwm.3_ch:
   type: Integer
@@ -151,15 +133,6 @@ pwm.3_def:
   min: 1000
   max: 2000
 
-pwm.3_feedback:
-  type: Integer
-  note: Indicates the operational mode of the node. 0 means disabled. When set to 1, the command of corresponding Status type for cmd_type will be transmitted (esc.RawCommand - esc.Status, actuator.ArrayCommand - actuator.Status) with frequency 1 Hz. When set to 2 - 10 Hz. 
-  enum: PARAM_PWM_3_FB
-  flags: mutable
-  default: 0
-  min: 0
-  max: 2
-
 pwm.4_ch:
   type: Integer
   note: Index of setpoint channel. [-1; 255]. -1 means disabled, # -2 means GPIO SET.
@@ -195,12 +168,3 @@ pwm.4_def:
   default: 1000
   min: 1000
   max: 2000
-
-pwm.4_feedback:
-  type: Integer
-  note: Indicates the operational mode of the node. 0 means disabled. When set to 1, the command of corresponding Status type for cmd_type will be transmitted (esc.RawCommand - esc.Status, actuator.ArrayCommand - actuator.Status) with frequency 1 Hz. When set to 2 - 10 Hz. 
-  enum: PARAM_PWM_4_FB
-  flags: mutable
-  default: 0
-  min: 0
-  max: 2

--- a/Src/peripheral/pwm/pwm.hpp
+++ b/Src/peripheral/pwm/pwm.hpp
@@ -41,6 +41,11 @@ public:
     static uint32_t get_duration(PwmPin pin);
 
     /**
+     * @return the duration of the PWM signal for a specific PWM pin in microseconds
+     */
+    static uint8_t get_percent(PwmPin pin, uint32_t min_duration_us, uint32_t max_duration_us);
+
+    /**
      * @return the frequency of the PWM signal for a specific PWM pin in Hz
      */
     static uint32_t get_frequency(PwmPin pwm_pin);

--- a/Src/platform/stm32/pwm/pwm.cpp
+++ b/Src/platform/stm32/pwm/pwm.cpp
@@ -5,6 +5,7 @@
  */
 
 #include "pwm.hpp"
+#include "common/algorithms.hpp"
 
 extern TIM_HandleTypeDef htim4;
 
@@ -33,6 +34,10 @@ uint32_t Pwm::get_duration(PwmPin pwm_pin) {
     }
 
     return pwms[static_cast<uint8_t>(pwm_pin)].ccr;
+}
+
+uint8_t Pwm::get_percent(PwmPin pin, uint32_t min_duration_us, uint32_t max_duration_us) {
+    return mapPwmToPct(get_duration(pin), min_duration_us, max_duration_us);
 }
 
 void Pwm::set_frequency(PwmPin pwm_pin, uint32_t frequency_hz) {

--- a/Src/platform/ubuntu/pwm.cpp
+++ b/Src/platform/ubuntu/pwm.cpp
@@ -5,6 +5,7 @@
  */
 
 #include "peripheral/pwm/pwm.hpp"
+#include "common/algorithms.hpp"
 
 namespace HAL {
 
@@ -22,6 +23,10 @@ void Pwm::set_duration(const PwmPin pwm_pin, uint32_t duration_us) {
 
 uint32_t Pwm::get_duration(PwmPin pwm_pin) {
     return pwm[(int)pwm_pin];
+}
+
+uint8_t Pwm::get_percent(PwmPin pin, uint32_t min_duration_us, uint32_t max_duration_us) {
+    return mapPwmToPct(get_duration(pin), min_duration_us, max_duration_us);
 }
 
 void Pwm::set_frequency(const PwmPin pwm_pin, uint32_t frequency_hz) {


### PR DESCRIPTION
This PR moves dronecan feedback logic from pwm module to a separate mode, cleans up dronecan circuit status logic and fixes bug with dronecan logger.

Changes in parameters:
- add crct.bitmask - it allows to enable/disable separate publishers and hardware checks
- use a single feedback.type instead of 4 similar parameters
- rename pwm params to be consistent with the cyphal specification

### Firmware image size difference

- dronecan_v2: 40144 -> 40788 (+644)
- dronecan_v3: 49276 -> 49904 (+628)
- cyphal_v2: +0
- cyphal_v3: +0

### Test coverage

- In SITL
- With mini v2 node
