### PR TITLE
Pr fft

### DIFF
--- a/Src/common/FFT.cpp
+++ b/Src/common/FFT.cpp
@@ -1,0 +1,205 @@
+
+/*
+ * Copyright (C) 2024 Stepanova Anastasiia <asiiapine@gmail.com>
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+#include <cstring>
+#include <cstdio>
+#include "FFT.hpp"
+#include "common/logging.hpp"
+
+Logging logger("FFT");
+bool FFT::init(uint16_t window_size, uint16_t num_axes, float sample_rate_hz) {
+    if (window_size > FFT_MAX_SIZE) {
+        return false;
+    }
+    n_axes = num_axes;
+    bool buffers_allocated = AllocateBuffers(window_size);
+    rfft_spec = init_rfft(&_hanning_window, &_fft_input_buffer,
+                          &_fft_output_buffer, window_size);
+    size = window_size;
+    _sample_rate_hz = sample_rate_hz;
+    _resolution_hz =  sample_rate_hz / size;
+    fft_max_freq = _sample_rate_hz / 2;
+    char buffer[100];
+    snprintf(buffer, sizeof(buffer), "_resolution_hz: %d, num_axes: %d, sample_rate_hz: %d",
+           (int)( _resolution_hz * 1000), n_axes, (int)(_sample_rate_hz * 1000));
+    logger.log_info(buffer);
+    return buffers_allocated;
+}
+
+void FFT::update(float *input) {
+    real_t conv_input[n_axes];
+    convert_float_to_real_t(input, conv_input, n_axes);
+    for (uint8_t axis = 0; axis < n_axes; axis++) {
+        uint16_t &buffer_index = _fft_buffer_index[axis];
+
+        if (buffer_index < size) {
+            // convert int16_t -> real_t (scaling isn't relevant)
+            data_buffer[axis][buffer_index] = conv_input[axis] / 2;
+            buffer_index++;
+            continue;
+        }
+
+        apply_hanning_window(data_buffer[axis].data(), _fft_input_buffer,
+                                _hanning_window, size);
+        rfft_one_cycle(rfft_spec, _fft_input_buffer, _fft_output_buffer);
+        _fft_updated = true;
+        find_peaks(axis);
+
+        // reset
+        // shift buffer (3/4 overlap)
+        const int overlap_start = size / 4;
+        memmove(&data_buffer[axis][0], &data_buffer[axis][overlap_start],
+                sizeof(real_t) * overlap_start * 3);
+        buffer_index = overlap_start * 3;
+        _fft_updated = false;
+    }
+}
+
+void FFT::find_peaks(uint8_t axis) {
+    // sum total energy across all used buckets for SNR
+    float bin_mag_sum = 0;
+    uint16_t num_peaks_found = 0;
+
+    float peak_magnitude[MAX_NUM_PEAKS] {};
+    uint16_t raw_peak_index[MAX_NUM_PEAKS] {};
+
+    static float peak_frequencies_prev[MAX_NUM_PEAKS] {};
+    for (int i = 0; i < MAX_NUM_PEAKS; i++) {
+        peak_frequencies_prev[i] = peak_frequencies[axis][i];
+    }
+
+    float fft_output_buffer_float[size];
+    convert_real_t_to_float(_fft_output_buffer, fft_output_buffer_float, size);
+
+    for (uint16_t fft_index = 0; fft_index < size/2; fft_index ++) {
+        real_t real_imag[2] = {0, 0};
+        get_real_imag_by_index(_fft_output_buffer, real_imag, size, fft_index);
+        float real_f, imag_f;
+        convert_real_t_to_float(&real_imag[0], &real_f, 1);
+        convert_real_t_to_float(&real_imag[1], &imag_f, 1);
+        const float fft_magnitude = sqrtf(real_f * real_f);
+        _peak_magnitudes_all[fft_index] = fft_magnitude;
+        bin_mag_sum += fft_magnitude;
+    }
+
+    for (uint8_t i = 0; i < MAX_NUM_PEAKS; i++) {
+        float largest_peak = 0;
+        uint16_t largest_peak_index = 0;
+
+        // Identify i'th peak bin
+        for (uint16_t bin_index = 1; bin_index < size/2; bin_index++) {
+            float frhz = float(_resolution_hz);
+            float fbi = float(bin_index);
+            float freq_hz = frhz * fbi;
+
+            if ((_peak_magnitudes_all[bin_index] > largest_peak)
+                && (freq_hz >= fft_min_freq)
+                && (freq_hz <= fft_max_freq)) {
+                largest_peak_index = bin_index;
+                largest_peak = _peak_magnitudes_all[bin_index];
+            }
+        }
+
+        if (largest_peak_index > 0) {
+            raw_peak_index[i] = largest_peak_index;
+            peak_magnitude[i] = _peak_magnitudes_all[largest_peak_index];
+            // remove peak + sides (included in frequency estimate later)
+            _peak_magnitudes_all[largest_peak_index - 1] = 0;
+            _peak_magnitudes_all[largest_peak_index]     = 0;
+            _peak_magnitudes_all[largest_peak_index + 1] = 0;
+        }
+    }
+
+    for (int peak_new = 0; peak_new < MAX_NUM_PEAKS; peak_new++) {
+        if (raw_peak_index[peak_new] == 0) {
+            continue;
+        }
+        float adjusted_bin = 0.5f *
+                        estimate_peak_freq(fft_output_buffer_float, 2 * raw_peak_index[peak_new]);
+        if (!std::isfinite(adjusted_bin)) {
+            continue;
+        }
+
+        float freq_adjusted = _resolution_hz * adjusted_bin;
+        // snr is in dB
+        const float snr = 10.f * log10f((size - 1) * peak_magnitude[peak_new] /
+                        (bin_mag_sum - peak_magnitude[peak_new]));
+
+        if (!std::isfinite(freq_adjusted)
+            || (snr < MIN_SNR)
+            || (freq_adjusted < fft_min_freq)
+            || (freq_adjusted > fft_max_freq)) {
+                continue;
+        }
+
+        // only keep if we're already tracking this frequency or
+        // if the SNR is significant
+        for (int peak_prev = 0; peak_prev < MAX_NUM_PEAKS; peak_prev++) {
+            bool peak_close = (fabsf(freq_adjusted - peak_frequencies_prev[peak_prev])
+                                < (_resolution_hz * 0.25f));
+            if (!peak_close && peak_frequencies_prev[peak_prev] > 0) {
+                continue;
+            }
+            // keep
+            peak_frequencies[axis][num_peaks_found] = freq_adjusted;
+            peak_snr[axis][num_peaks_found] = snr;
+
+            // remove
+            if (peak_close) {
+                peak_frequencies_prev[peak_prev] = NAN;
+            }
+            num_peaks_found++;
+            break;
+        }
+    }
+}
+
+static constexpr float tau(float x) {
+    // tau(x) = 1/4 * log(3*x*x + 6*x + 1) - sqrt(6)/24*log((x + 1 - sqrt(2/3))/(x + 1 + sqrt(2/3)))
+    float addend_1 = 1/4 * logf(3 * x * x + 6 * x + 1);
+    float multiplier_2 = sqrtf(6) / 24;
+    float addend_2 = logf((x + 1 - sqrtf(2 / 3)) / (x + 1 + sqrtf(2 / 3)));
+    return addend_1 - multiplier_2 * addend_2;
+}
+
+float FFT::estimate_peak_freq(float fft[], int peak_index) {
+    if (peak_index < 2) {
+        return NAN;
+    }
+
+    // find peak location using Quinn's Second Estimator (2020-06-14: http://dspguru.com/dsp/howtos/how-to-interpolate-fft-peak/)
+    float real_imag[3][2];
+    float real[3];
+    float imag[3];
+    for (int i = -1; i < 2; i++) {
+        get_real_imag_by_index(fft, real_imag[i + 1], size, peak_index + i);
+        real[i + 1] = real_imag[i + 1][0];
+        imag[i + 1] = real_imag[i + 1][1];
+    }
+
+    static constexpr int k = 1;
+
+    const float divider = (real[k] * real[k] + imag[k] * imag[k]);
+
+    // ap = (X[k + 1].r * X[k].r + X[k+1].i * X[k].i) / (X[k].r * X[k].r + X[k].i * X[k].i)
+    float ap = (real[k + 1] * real[k] + imag[k + 1] * imag[k]) / divider;
+
+    // dp = -ap / (1 – ap)
+    float dp = -ap  / (1.f - ap);
+
+    // am = (X[k - 1].r * X[k].r + X[k – 1].i * X[k].i) / (X[k].r * X[k].r + X[k].i * X[k].i)
+    float am = (real[k - 1] * real[k] + imag[k - 1] * imag[k]) / divider;
+
+    // dm = am / (1 – am)
+    float dm = am / (1.f - am);
+
+    // d = (dp + dm) / 2 + tau(dp * dp) – tau(dm * dm)
+    float d = (dp + dm) / 2.f + tau(dp * dp) - tau(dm * dm);
+
+    // k’ = k + d
+    return peak_index + 2.f * d;
+}

--- a/Src/common/FFT.cpp
+++ b/Src/common/FFT.cpp
@@ -159,12 +159,15 @@ void FFT::find_peaks(uint8_t axis) {
         }
     }
     float max_snr_peak = 0;
+    uint8_t max_peak_index = 0;
     for (int peak_index = 0; peak_index < MAX_NUM_PEAKS; peak_index++) {
         if (peak_snr[axis][peak_index] > max_snr_peak) {
-            max_snr_peak = peak_frequencies[axis][peak_index];
+            max_snr_peak = peak_snr[axis][peak_index];
+            max_peak_index = peak_index;
         }
     }
-    peak_frequencies[axis][0] = max_snr_peak;
+    peak_frequencies[axis][0] = peak_frequencies[axis][max_peak_index];
+    peak_snr[axis][0] = peak_snr[axis][max_peak_index];
 }
 
 static constexpr float tau(float x) {

--- a/Src/common/FFT.hpp
+++ b/Src/common/FFT.hpp
@@ -19,7 +19,7 @@ extern "C" {
 #define FFT_MAX_SIZE    2048
 #define MAX_NUM_PEAKS   3
 #define MIN_SNR         1.0f
-#define NUM_AXES        3
+#define MAX_NUM_AXES        3
 
 class FFT {
 public:
@@ -28,12 +28,13 @@ public:
     float fft_min_freq = 0;
     float fft_max_freq;
     float _resolution_hz;
-    float peak_frequencies [NUM_AXES][MAX_NUM_PEAKS] {};
-    float peak_snr [NUM_AXES][MAX_NUM_PEAKS] {};
+    float peak_frequencies [MAX_NUM_AXES][MAX_NUM_PEAKS] {0};
+    float peak_snr [MAX_NUM_AXES][MAX_NUM_PEAKS] {0};
+    bool _fft_updated[MAX_NUM_AXES]{false};
+    uint32_t total_time;
 
 private:
     uint16_t size;
-
     real_t *_hanning_window{nullptr};
     real_t *_fft_output_buffer{nullptr};
     real_t *_fft_input_buffer{nullptr};
@@ -41,7 +42,6 @@ private:
     std::vector<float> _peak_magnitudes_all;
 
     uint16_t _fft_buffer_index[3] {};
-    bool _fft_updated{false};
     uint8_t n_axes;
     float _sample_rate_hz;
 
@@ -56,14 +56,14 @@ private:
         return (data_buffer[0].data() && data_buffer[1].data() && data_buffer[2].data()
                 && _peak_magnitudes_all.data());
     }
-    // #ifdef HAL_MODULE_ENABLED
+    #ifdef HAL_MODULE_ENABLED
         // specification of arm_rfft_instance_q15
         // https://arm-software.github.io/CMSIS_5/DSP/html/group__RealFFT.html
         arm_rfft_instance_q15 rfft_spec;
-    // #else
+    #else
         // plan for the r2c transform from fftw3 library.
-        // fftw_plan rfft_spec;
-    // #endif
+        fftw_plan rfft_spec;
+    #endif
 };
 
 #ifdef __cplusplus

--- a/Src/common/FFT.hpp
+++ b/Src/common/FFT.hpp
@@ -1,0 +1,73 @@
+/*
+ * Copyright (C) 2024 Anastasiia Stepanova <asiiapine@gmail.com>
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+#ifndef SRC_COMMON_ALGORITHMS_FFT_H_
+#define SRC_COMMON_ALGORITHMS_FFT_H_
+
+#include <vector>
+#include "rfft.hpp"
+#include "main.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define FFT_MAX_SIZE    2048
+#define MAX_NUM_PEAKS   3
+#define MIN_SNR         1.0f
+#define NUM_AXES        3
+
+class FFT {
+public:
+    bool init(uint16_t window_size, uint16_t num_axes, float sample_rate_hz);
+    void update(float *input);
+    float fft_min_freq = 0;
+    float fft_max_freq;
+    float _resolution_hz;
+    float peak_frequencies [NUM_AXES][MAX_NUM_PEAKS] {};
+    float peak_snr [NUM_AXES][MAX_NUM_PEAKS] {};
+
+private:
+    uint16_t size;
+
+    real_t *_hanning_window{nullptr};
+    real_t *_fft_output_buffer{nullptr};
+    real_t *_fft_input_buffer{nullptr};
+    std::vector<std::vector<real_t>> data_buffer;
+    std::vector<float> _peak_magnitudes_all;
+
+    uint16_t _fft_buffer_index[3] {};
+    bool _fft_updated{false};
+    uint8_t n_axes;
+    float _sample_rate_hz;
+
+    float estimate_peak_freq(float fft[], int peak_index);
+    void find_peaks(uint8_t axis);
+    bool AllocateBuffers(uint16_t N) {
+        data_buffer.resize(n_axes);
+        for (int i = 0; i < n_axes; i++) {
+            data_buffer[i].resize(N);
+        }
+        _peak_magnitudes_all.resize(N);
+        return (data_buffer[0].data() && data_buffer[1].data() && data_buffer[2].data()
+                && _peak_magnitudes_all.data());
+    }
+    // #ifdef HAL_MODULE_ENABLED
+        // specification of arm_rfft_instance_q15
+        // https://arm-software.github.io/CMSIS_5/DSP/html/group__RealFFT.html
+        arm_rfft_instance_q15 rfft_spec;
+    // #else
+        // plan for the r2c transform from fftw3 library.
+        // fftw_plan rfft_spec;
+    // #endif
+};
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // SRC_COMMON_ALGORITHMS_FFT_H_

--- a/Src/drivers/mpu9250/mpu9250.cpp
+++ b/Src/drivers/mpu9250/mpu9250.cpp
@@ -17,7 +17,7 @@ enum class Mpu9250Resgiter : uint8_t {
 
 // Register Map for Magnetometer (AK8963)
 enum class MagnetometerResgiter : uint8_t {
-    REG_MAG_XOUT_L = 0x03,
+    REG_MAG_XOUT_L  = 0x03,
 };
 
 constexpr auto MPU9250_WHO_AM_I_ID = std::byte(0x71);   // REG_WHO_AM_I expected value

--- a/Src/drivers/mpu9250/mpu9250.hpp
+++ b/Src/drivers/mpu9250/mpu9250.hpp
@@ -35,9 +35,6 @@ public:
      */
     int8_t read_magnetometer(std::array<int16_t, 3>* mag) const;
 
-    int8_t set_accel_odr(uint8_t odr);
-
-    int8_t set_gyro_odr(uint8_t odr);
 private:
     bool initialized{false};
 };

--- a/Src/drivers/mpu9250/mpu9250.hpp
+++ b/Src/drivers/mpu9250/mpu9250.hpp
@@ -34,6 +34,10 @@ public:
      * @return 0 on success, negative otherwise
      */
     int8_t read_magnetometer(std::array<int16_t, 3>* mag) const;
+
+    int8_t set_accel_odr(uint8_t odr);
+
+    int8_t set_gyro_odr(uint8_t odr);
 private:
     bool initialized{false};
 };

--- a/Src/modules/imu/imu.cpp
+++ b/Src/modules/imu/imu.cpp
@@ -10,8 +10,16 @@
 REGISTER_MODULE(ImuModule)
 
 void ImuModule::init() {
-    initialized = imu.initialize();
+    logger = Logging("IMU");
+    bool imu_initialized = imu.initialize();
     mode = Module::Mode::STANDBY;
+    uint16_t num_axes = 3;
+    uint16_t window_size = 512;
+    bool fft_initialized = fft.init(window_size, num_axes, 1000.0f/period_ms);
+    initialized = imu_initialized && fft_initialized;
+    // snprintf(buffer, sizeof(buffer), "initialized: %d %d", imu_initialized, fft_initialized);
+    // logger.log_info(buffer);
+    // logger.log_info("initialized");
 }
 
 void ImuModule::update_params() {
@@ -20,6 +28,14 @@ void ImuModule::update_params() {
     if (enabled) {
         mode = initialized ? Mode::STANDBY : Mode::INITIALIZATION;
     }
+    // static uint32_t prev_time = HAL_GetTick();
+    // if (prev_time + 1000 < HAL_GetTick()) {
+    //     prev_time = HAL_GetTick();
+    //     char buffer[90];
+    //     snprintf(buffer, sizeof(buffer), "enabled: %d %d %d", enabled, initialized,
+    //                 static_cast<int>(mode));
+    //     logger.log_info(buffer);
+    // }
 }
 
 void ImuModule::spin_once() {
@@ -34,24 +50,53 @@ void ImuModule::spin_once() {
 
     bool updated{false};
 
-    std::array<int16_t, 3> accel_raw;
-    if (imu.read_accelerometer(&accel_raw) >= 0) {
-        pub.msg.accelerometer_latest[0] = raw_accel_to_meter_per_square_second(accel_raw[0]);
-        pub.msg.accelerometer_latest[1] = raw_accel_to_meter_per_square_second(accel_raw[1]);
-        pub.msg.accelerometer_latest[2] = raw_accel_to_meter_per_square_second(accel_raw[2]);
+    std::array<int16_t, 3> accel_raw = {0, 0, 0};
+    std::array<int16_t, 3> gyro_raw = {0, 0, 0};
+
+    static std::vector<float> gyro;
+    if (imu.read_gyroscope(&gyro_raw) >= 0) {
+        gyro = {raw_gyro_to_rad_per_second(gyro_raw[0]),
+                raw_gyro_to_rad_per_second(gyro_raw[1]),
+                raw_gyro_to_rad_per_second(gyro_raw[2])};
+        pub.msg.rate_gyro_latest[0] = gyro[0];
+        pub.msg.rate_gyro_latest[1] = gyro[1];
+        pub.msg.rate_gyro_latest[2] = gyro[2];
+        // fft.update(gyro.data());
         updated = true;
     }
 
-    std::array<int16_t, 3> gyro_raw;
-    if (imu.read_gyroscope(&gyro_raw) >= 0) {
-        pub.msg.rate_gyro_latest[0] = raw_gyro_to_rad_per_second(gyro_raw[0]);
-        pub.msg.rate_gyro_latest[1] = raw_gyro_to_rad_per_second(gyro_raw[1]);
-        pub.msg.rate_gyro_latest[2] = raw_gyro_to_rad_per_second(gyro_raw[2]);
+    auto status = imu.read_accelerometer(&accel_raw);
+    if (status >= 0) {
+        static float accel[3] = {
+                raw_accel_to_meter_per_square_second(accel_raw[0]),
+                raw_accel_to_meter_per_square_second(accel_raw[1]),
+                raw_accel_to_meter_per_square_second(accel_raw[2])};
+        pub.msg.accelerometer_latest[0] = accel[0];
+        pub.msg.accelerometer_latest[1] = accel[1];
+        pub.msg.accelerometer_latest[2] = accel[2];
+        // fft.update(accel);
         updated = true;
+    } else {
+        updated = false;
     }
 
     if (updated) {
         pub.msg.timestamp = HAL_GetTick() * 1000;
         pub.publish();
+    }
+    static uint32_t prev_time = HAL_GetTick();
+    if (prev_time + 1000 < HAL_GetTick()) {
+        prev_time = HAL_GetTick();
+        char buffer[90];
+        snprintf(buffer, sizeof(buffer), "mode: %d",
+                    static_cast<int>(mode));
+        // snprintf(buffer, sizeof(buffer), "peak freq: %d %d %d snr: %d %d %d",
+        //         (int)(fft.peak_frequencies[0][0]),
+        //         (int)(fft.peak_frequencies[1][0]),
+        //         (int)(fft.peak_frequencies[2][0]),
+        //         (int)(fft.peak_snr[0][0]),
+        //         (int)(fft.peak_snr[1][0]),
+        //         (int)(fft.peak_snr[2][0]));
+        logger.log_info(buffer);
     }
 }

--- a/Src/modules/imu/imu.cpp
+++ b/Src/modules/imu/imu.cpp
@@ -16,10 +16,8 @@ void ImuModule::init() {
     uint16_t num_axes = 3;
     uint16_t window_size = 512;
     bool fft_initialized = fft.init(window_size, num_axes, 1000.0f/period_ms);
+    fft.fft_min_freq = 10;
     initialized = imu_initialized && fft_initialized;
-    // snprintf(buffer, sizeof(buffer), "initialized: %d %d", imu_initialized, fft_initialized);
-    // logger.log_info(buffer);
-    // logger.log_info("initialized");
 }
 
 void ImuModule::update_params() {
@@ -28,14 +26,6 @@ void ImuModule::update_params() {
     if (enabled) {
         mode = initialized ? Mode::STANDBY : Mode::INITIALIZATION;
     }
-    // static uint32_t prev_time = HAL_GetTick();
-    // if (prev_time + 1000 < HAL_GetTick()) {
-    //     prev_time = HAL_GetTick();
-    //     char buffer[90];
-    //     snprintf(buffer, sizeof(buffer), "enabled: %d %d %d", enabled, initialized,
-    //                 static_cast<int>(mode));
-    //     logger.log_info(buffer);
-    // }
 }
 
 void ImuModule::spin_once() {
@@ -48,55 +38,51 @@ void ImuModule::spin_once() {
         mag.publish();
     }
 
-    bool updated{false};
+    bool updated[2]{false, false};
 
     std::array<int16_t, 3> accel_raw = {0, 0, 0};
-    std::array<int16_t, 3> gyro_raw = {0, 0, 0};
+    std::array<int16_t, 3> gyro_raw  = {0, 0, 0};
 
-    static std::vector<float> gyro;
     if (imu.read_gyroscope(&gyro_raw) >= 0) {
-        gyro = {raw_gyro_to_rad_per_second(gyro_raw[0]),
+        float gyro[3] = {
+                raw_gyro_to_rad_per_second(gyro_raw[0]),
                 raw_gyro_to_rad_per_second(gyro_raw[1]),
                 raw_gyro_to_rad_per_second(gyro_raw[2])};
         pub.msg.rate_gyro_latest[0] = gyro[0];
         pub.msg.rate_gyro_latest[1] = gyro[1];
         pub.msg.rate_gyro_latest[2] = gyro[2];
-        // fft.update(gyro.data());
-        updated = true;
+        fft.update(gyro);
+        updated[0] = true;
     }
 
-    auto status = imu.read_accelerometer(&accel_raw);
-    if (status >= 0) {
-        static float accel[3] = {
+    if (imu.read_accelerometer(&accel_raw) >= 0) {
+        float accel[3] = {
                 raw_accel_to_meter_per_square_second(accel_raw[0]),
                 raw_accel_to_meter_per_square_second(accel_raw[1]),
                 raw_accel_to_meter_per_square_second(accel_raw[2])};
         pub.msg.accelerometer_latest[0] = accel[0];
         pub.msg.accelerometer_latest[1] = accel[1];
         pub.msg.accelerometer_latest[2] = accel[2];
-        // fft.update(accel);
-        updated = true;
-    } else {
-        updated = false;
+        updated[1] = true;
     }
 
-    if (updated) {
+    if (updated[0] && updated[1]) {
         pub.msg.timestamp = HAL_GetTick() * 1000;
         pub.publish();
     }
+
     static uint32_t prev_time = HAL_GetTick();
-    if (prev_time + 1000 < HAL_GetTick()) {
+    if (prev_time + 1000 < HAL_GetTick() || fft._fft_updated[0]) {
         prev_time = HAL_GetTick();
-        char buffer[90];
-        snprintf(buffer, sizeof(buffer), "mode: %d",
-                    static_cast<int>(mode));
-        // snprintf(buffer, sizeof(buffer), "peak freq: %d %d %d snr: %d %d %d",
-        //         (int)(fft.peak_frequencies[0][0]),
-        //         (int)(fft.peak_frequencies[1][0]),
-        //         (int)(fft.peak_frequencies[2][0]),
-        //         (int)(fft.peak_snr[0][0]),
-        //         (int)(fft.peak_snr[1][0]),
-        //         (int)(fft.peak_snr[2][0]));
+        char buffer[60];
+        snprintf(buffer, sizeof(buffer), "peaks\nfreq: %d %d %d\n snrs: %d %d %d",
+                (int)(fft.peak_frequencies[0][0]),
+                (int)(fft.peak_frequencies[1][0]),
+                (int)(fft.peak_frequencies[2][0]),
+                (int)(fft.peak_snr[0][0]),
+                (int)(fft.peak_snr[1][0]),
+                (int)(fft.peak_snr[2][0])
+                );
         logger.log_info(buffer);
     }
 }

--- a/Src/modules/imu/imu.hpp
+++ b/Src/modules/imu/imu.hpp
@@ -20,7 +20,7 @@ extern "C" {
 
 class ImuModule : public Module {
 public:
-    ImuModule() : Module(400.0, Protocol::DRONECAN) {}
+    ImuModule() : Module(00.0, Protocol::DRONECAN) {}
     void init() override;
 
 protected:

--- a/Src/modules/imu/imu.hpp
+++ b/Src/modules/imu/imu.hpp
@@ -4,13 +4,15 @@
  * Author: Dmitry Ponomarev <ponomarevda96@gmail.com>
  */
 
-#ifndef SRC_MODULES_CANOPEN_HPP_
-#define SRC_MODULES_CANOPEN_HPP_
+#ifndef SRC_MODULES_IMU_HPP_
+#define SRC_MODULES_IMU_HPP_
 
 #include <numbers>
 #include "module.hpp"
 #include "publisher.hpp"
 #include "drivers/mpu9250/mpu9250.hpp"
+#include "common/FFT.hpp"
+#include "common/logging.hpp"
 
 #ifdef __cplusplus
 extern "C" {
@@ -18,7 +20,7 @@ extern "C" {
 
 class ImuModule : public Module {
 public:
-    ImuModule() : Module(10.0) {}
+    ImuModule() : Module(400.0, Protocol::DRONECAN) {}
     void init() override;
 
 protected:
@@ -29,6 +31,8 @@ private:
     DronecanPublisher<AhrsRawImu> pub;
     DronecanPublisher<MagneticFieldStrength2> mag;
     Mpu9250 imu;
+    FFT fft;
+    Logging logger{"IMU"};
     bool initialized{false};
     bool enabled{false};
 
@@ -45,4 +49,4 @@ private:
 }
 #endif
 
-#endif  // SRC_MODULES_CANOPEN_HPP_
+#endif  // SRC_MODULES_IMU_HPP_

--- a/Src/modules/imu/imu.hpp
+++ b/Src/modules/imu/imu.hpp
@@ -20,7 +20,7 @@ extern "C" {
 
 class ImuModule : public Module {
 public:
-    ImuModule() : Module(00.0, Protocol::DRONECAN) {}
+    ImuModule() : Module(400.0, Protocol::DRONECAN) {}
     void init() override;
 
 protected:

--- a/Src/platform/stm32g0b1/CMakeLists.txt
+++ b/Src/platform/stm32g0b1/CMakeLists.txt
@@ -10,6 +10,7 @@ set(EXECUTABLE ${PROJECT_NAME}.out)
 add_executable(${EXECUTABLE}
     ${APPLICATION_SOURCES}
     ${BUILD_SRC_DIR}/params.cpp
+    ${ROOT_DIR}/Src/common/FFT.cpp
     ${ROOT_DIR}/Src/common/algorithms.cpp
     ${ROOT_DIR}/Src/common/logging.cpp
     ${ROOT_DIR}/Src/common/application.cpp
@@ -35,9 +36,10 @@ target_include_directories(${EXECUTABLE} PRIVATE
     ${BUILD_SRC_DIR}
     ${APPLICATION_HEADERS}
     ${ROOT_DIR}/Src/common
-
+    ${CMAKE_CURRENT_LIST_DIR}
     ${stm32cubeMxProjectPath}/Core/Inc
     ${stm32cubeMxProjectPath}/Drivers/CMSIS/Include
+    ${stm32cubeMxProjectPath}/Drivers/CMSIS/DSP/Include
 
     ${stm32cubeMxProjectPath}/Drivers/CMSIS/Device/ST/STM32F1xx/Include
     ${stm32cubeMxProjectPath}/Drivers/STM32F1xx_HAL_Driver/Inc

--- a/Src/platform/stm32g0b1/rfft.hpp
+++ b/Src/platform/stm32g0b1/rfft.hpp
@@ -17,9 +17,9 @@ The function specifies arm_rfft_instance_q15 from CMSIS-DSP library based on the
 @return: The plan for the r2c transform.
 */
 inline arm_rfft_instance_q15 init_rfft(real_t** hanning_window, real_t** in,
-                                        real_t** out, uint16_t N) {
+                                        real_t** out, uint16_t *N) {
     arm_rfft_instance_q15 _rfft_q15;
-    switch (N) {
+    switch (*N) {
         case 256:
             _rfft_q15.fftLenReal = 256;
             _rfft_q15.twidCoefRModifier = 32U;
@@ -38,7 +38,7 @@ inline arm_rfft_instance_q15 init_rfft(real_t** hanning_window, real_t** in,
             _rfft_q15.pCfft = &arm_cfft_sR_q15_len512;
             break;
         default:
-            N = 256;
+            *N = 256;
             _rfft_q15.fftLenReal = 256;
             _rfft_q15.twidCoefRModifier = 32U;
             _rfft_q15.pCfft = &arm_cfft_sR_q15_len128;
@@ -52,11 +52,11 @@ inline arm_rfft_instance_q15 init_rfft(real_t** hanning_window, real_t** in,
     // *out = new real_t[N * 2];
     // *hanning_window = new real_t[N];
 
-    *in = (real_t*)calloc(N, sizeof(real_t));
-    *out = (real_t*)calloc(N * 2, sizeof(real_t));
-    *hanning_window = (real_t*)calloc(N, sizeof(real_t));
-    for (int n = 0; n < N; n++) {
-        const float hanning_value = 0.5f * (1.f - cos(M_2PI * n / (N - 1)));
+    *in = (real_t*)calloc(*N, sizeof(real_t));
+    *out = (real_t*)calloc(*N * 2, sizeof(real_t));
+    *hanning_window = (real_t*)calloc(*N, sizeof(real_t));
+    for (int n = 0; n < *N; n++) {
+        const float hanning_value = 0.5f * (1.f - cos(M_2PI * n / (*N - 1)));
         (*hanning_window)[n] = hanning_value;
         arm_float_to_q15(&hanning_value,  &(*hanning_window)[n], 1);
     }
@@ -100,6 +100,16 @@ inline void get_real_imag_by_index(T* in, T* out, uint16_t N, int index) {
     (void)N;
     out[0] = in[2 * index];
     out[1] = in[2 * index + 1];
+}
+
+template<typename T>
+inline T get_real_by_index(T* in, int index) {
+    return in[index];
+}
+
+template<typename T>
+inline T get_imag_by_index(T* in, int index) {
+    return in[index + 1];
 }
 
 #endif  // SRC_PLATFORM_STM32_MATH_RFFT_HPP_

--- a/Src/platform/stm32g0b1/rfft.hpp
+++ b/Src/platform/stm32g0b1/rfft.hpp
@@ -1,0 +1,105 @@
+#ifndef SRC_PLATFORM_STM32_MATH_RFFT_HPP_
+#define SRC_PLATFORM_STM32_MATH_RFFT_HPP_
+
+#include "arm_math.h"
+#include "arm_const_structs.h"
+typedef q15_t real_t;
+#define M_2PI           6.28318530717958647692
+
+
+/*
+The function specifies arm_rfft_instance_q15 from CMSIS-DSP library based on the window size.
+@param window_size: The size of the input array.
+@param hanning_window: Pointer to the Hanning window container.
+@param in: used fo incompatability with ubuntu version
+@param out: used fo incompatability with ubuntu version
+@param N: The size of the Hanning window.
+@return: The plan for the r2c transform.
+*/
+inline arm_rfft_instance_q15 init_rfft(real_t** hanning_window, real_t** in,
+                                        real_t** out, uint16_t N) {
+    arm_rfft_instance_q15 _rfft_q15;
+    switch (N) {
+        case 256:
+            _rfft_q15.fftLenReal = 256;
+            _rfft_q15.twidCoefRModifier = 32U;
+            _rfft_q15.pCfft = &arm_cfft_sR_q15_len128;
+            break;
+
+        case 512:
+            _rfft_q15.fftLenReal = 512;
+            _rfft_q15.twidCoefRModifier = 16U;
+            _rfft_q15.pCfft = &arm_cfft_sR_q15_len256;
+            break;
+
+        case 1024:
+            _rfft_q15.fftLenReal = 1024;
+            _rfft_q15.twidCoefRModifier = 8U;
+            _rfft_q15.pCfft = &arm_cfft_sR_q15_len512;
+            break;
+        default:
+            N = 256;
+            _rfft_q15.fftLenReal = 256;
+            _rfft_q15.twidCoefRModifier = 32U;
+            _rfft_q15.pCfft = &arm_cfft_sR_q15_len128;
+    }
+    _rfft_q15.pTwiddleAReal = (real_t *) realCoefAQ15;
+    _rfft_q15.pTwiddleBReal = (real_t *) realCoefBQ15;
+    _rfft_q15.ifftFlagR = 0;
+    _rfft_q15.bitReverseFlagR = 1;
+
+    // *in = new real_t[N];
+    // *out = new real_t[N * 2];
+    // *hanning_window = new real_t[N];
+
+    *in = (real_t*)calloc(N, sizeof(real_t));
+    *out = (real_t*)calloc(N * 2, sizeof(real_t));
+    *hanning_window = (real_t*)calloc(N, sizeof(real_t));
+    for (int n = 0; n < N; n++) {
+        const float hanning_value = 0.5f * (1.f - cos(M_2PI * n / (N - 1)));
+        (*hanning_window)[n] = hanning_value;
+        arm_float_to_q15(&hanning_value,  &(*hanning_window)[n], 1);
+    }
+
+    return _rfft_q15;
+}
+
+/*
+The function is written based on CMSIS-DSP library.
+@param in: The input array.
+@param out: The output array.
+@param hanning_window: The Hanning window.
+@param N: The size of the Hanning window.
+*/
+inline void apply_hanning_window(real_t* in, real_t* out, real_t* hanning_window, int N) {
+    arm_mult_q15(in, hanning_window, out, N);
+}
+
+/*
+The function is written based on CMSIS-DSP library.
+@param _rfft_q15: The plan for the r2c transform.
+@param in: The input array.
+@param out: The output array.
+*/
+inline void rfft_one_cycle(arm_rfft_instance_q15 _rfft_q15, real_t* in, real_t* out) {
+    arm_rfft_q15(&_rfft_q15, in, out);
+}
+
+inline void convert_real_t_to_float(real_t* in, float* out, uint16_t N) {
+    arm_q15_to_float(in, out, N);
+}
+
+inline void convert_float_to_real_t(float* in, real_t* out, uint16_t N) {
+    arm_float_to_q15(in, out, N);
+}
+
+// FFT output buffer is ordered as follows:
+    // [real[0], imag[0], real[1], imag[1], real[2], imag[2] ... real[(N/2)-1], imag[(N/2)-1]
+template<typename T>
+inline void get_real_imag_by_index(T* in, T* out, uint16_t N, int index) {
+    (void)N;
+    out[0] = in[2 * index];
+    out[1] = in[2 * index + 1];
+}
+
+#endif  // SRC_PLATFORM_STM32_MATH_RFFT_HPP_

--- a/Src/platform/ubuntu/rfft.hpp
+++ b/Src/platform/ubuntu/rfft.hpp
@@ -1,0 +1,70 @@
+/* These definitions need to be changed depending on the floating-point precision */
+#pragma once
+#ifndef SRC_PLATFORM_UBUNTU_MATH_RFFT_HPP_
+#define SRC_PLATFORM_UBUNTU_MATH_RFFT_HPP_
+
+typedef double real_t;
+#include <fftw3.h>
+#include <iostream>
+#include <vector>
+#include <complex>
+
+#define M_2PI           6.28318530717958647692
+
+inline fftw_plan init_rfft(real_t** hanning_window, real_t** in, real_t** out, uint16_t N) {
+    *hanning_window = fftw_alloc_real(N);
+    for (int n = 0; n < N; n++) {
+        const float hanning_value = 0.5f * (1.f - cos(M_2PI * n / (N - 1)));
+        (*hanning_window)[n] = hanning_value;
+    }
+    // Allocate input and output arrays
+    *in = (real_t*) fftw_alloc_real(sizeof(real_t)*N);
+    *out = (real_t*) fftw_alloc_real(sizeof(real_t)*N);
+    // Create plan
+    return fftw_plan_r2r_1d(N, *in, *out, FFTW_R2HC, FFTW_ESTIMATE);
+}
+
+/*
+The function apply_hanning_window applies the Hanning window to the input array.
+@param in: The input array.
+@param out: The output array.
+@param hanning_window: The Hanning window.
+@param N: The size of the input array.
+*/
+inline void apply_hanning_window(real_t* in, real_t* out, real_t* hanning_window, int N) {
+    for (int i = 0; i < N; i++) {
+        out[i] = hanning_window[i] * in[i];
+    }
+}
+
+// FFT output buffer is ordered as follows:
+    // [real[0], real[1], real[2], ... real[(N/2)-1], imag[0], imag[1], imag[2], ... imag[(N/2)-1]
+template<typename T>
+inline void get_real_imag_by_index(T* in, T out[2], uint16_t N, int index) {
+    out[0] = in[index];
+    // For FFTW_R2HC kind the imaginary part is zero
+    // due to symmetries of the real-input DFT, and is not stored
+    out[1] = 0;
+}
+
+/*
+The function written based on fftw3 library.
+@param plan: The plan for the r2c transform.
+*/
+inline void rfft_one_cycle(fftw_plan plan, real_t* in, real_t* out) {
+    fftw_execute_r2r(plan, in, out);
+}
+
+inline void convert_real_t_to_float(real_t* in, float* out, uint16_t N) {
+    for (int n = 0; n < N; n++) {
+        out[n] = (float)in[n];
+    }
+}
+
+inline void convert_float_to_real_t(float* in, real_t* out, uint16_t N) {
+    for (int n = 0; n < N; n++) {
+        out[n] = (real_t)in[n];
+    }
+}
+
+#endif  // SRC_PLATFORM_UBUNTU_MATH_RFFT_HPP_

--- a/Src/platform/ubuntu/rfft.hpp
+++ b/Src/platform/ubuntu/rfft.hpp
@@ -11,17 +11,17 @@ typedef double real_t;
 
 #define M_2PI           6.28318530717958647692
 
-inline fftw_plan init_rfft(real_t** hanning_window, real_t** in, real_t** out, uint16_t N) {
-    *hanning_window = fftw_alloc_real(N);
-    for (int n = 0; n < N; n++) {
-        const float hanning_value = 0.5f * (1.f - cos(M_2PI * n / (N - 1)));
+inline fftw_plan init_rfft(real_t** hanning_window, real_t** in, real_t** out, uint16_t *N) {
+    *hanning_window = fftw_alloc_real(*N);
+    for (int n = 0; n < *N; n++) {
+        const float hanning_value = 0.5f * (1.f - cos(M_2PI * n / (*N - 1)));
         (*hanning_window)[n] = hanning_value;
     }
     // Allocate input and output arrays
-    *in = (real_t*) fftw_alloc_real(sizeof(real_t)*N);
-    *out = (real_t*) fftw_alloc_real(sizeof(real_t)*N);
+    *in = (real_t*) fftw_alloc_real(sizeof(real_t)* (*N));
+    *out = (real_t*) fftw_alloc_real(sizeof(real_t)* 2 * *N);
     // Create plan
-    return fftw_plan_r2r_1d(N, *in, *out, FFTW_R2HC, FFTW_ESTIMATE);
+    return fftw_plan_r2r_1d(*N, *in, *out, FFTW_R2HC, FFTW_ESTIMATE);
 }
 
 /*
@@ -42,11 +42,20 @@ inline void apply_hanning_window(real_t* in, real_t* out, real_t* hanning_window
 template<typename T>
 inline void get_real_imag_by_index(T* in, T out[2], uint16_t N, int index) {
     out[0] = in[index];
-    // For FFTW_R2HC kind the imaginary part is zero
-    // due to symmetries of the real-input DFT, and is not stored
     out[1] = 0;
 }
 
+template<typename T>
+inline T get_real_by_index(T* in, uint16_t index) {
+    return in[index];
+}
+
+// For FFTW_R2HC kind the imaginary part is zero
+// due to symmetries of the real-input DFT, and is not stored
+template<typename T>
+inline T get_imag_by_index(T* in, uint16_t index) {
+    return 0;
+}
 /*
 The function written based on fftw3 library.
 @param plan: The plan for the r2c transform.

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -1,0 +1,53 @@
+cmake_minimum_required(VERSION 3.15.3)
+project(tests CXX C)
+
+set(TESTS_DIR ${CMAKE_CURRENT_LIST_DIR})
+cmake_path(GET TESTS_DIR PARENT_PATH ROOT_DIR)
+
+message(STATUS "ROOT_DIR: ${ROOT_DIR}")
+message(STATUS "CMAKE_CURRENT_LIST_DIR: ${CMAKE_CURRENT_LIST_DIR}")
+message(STATUS "CMAKE_CURRENT_SOURCE_DIR: ${CMAKE_CURRENT_SOURCE_DIR}")
+message(STATUS "CRNT_DIR: ${CRNT_DIR}")
+
+# Check if the COVERAGE flag is set
+option(COVERAGE "Enable coverage flags" OFF)
+option(TEST_NUM "Enable test num" OFF)
+if(COVERAGE EQUAL 1)
+    message(STATUS "Code coverage enabled!")
+    add_compile_options(-g -O0 --coverage)
+    add_link_options(--coverage)
+endif()
+
+enable_testing()
+find_package(GTest REQUIRED)
+include_directories(${GTEST_INCLUDE_DIR})
+
+find_package(PkgConfig REQUIRED)
+pkg_search_module(FFTW REQUIRED fftw3)
+include_directories(${FFTW_INCLUDE_DIRS})
+FILE(GLOB commonSources       ${ROOT_DIR}/Src/common/FFT.cpp
+                              ${ROOT_DIR}/Src/common/algorithms.cpp)
+
+function(gen_test app_name test_file)
+    # Create the executable target
+    add_executable(${app_name}
+                   ${commonSources}
+                   ${test_file})
+
+    # Include directories for the target
+    target_include_directories(${app_name} PUBLIC ${ROOT_DIR}/Src/common ${ROOT_DIR}/Src/platform/ubuntu)
+    
+    # Link libraries to the target
+    target_link_libraries(${app_name} GTest::gtest GTest::gtest_main ${FFTW_LIBRARIES} m stdc++)
+    
+    # Printing the target properties (optional, can be removed)
+    get_target_property(var ${app_name} INCLUDE_DIRECTORIES)
+    message(STATUS "${app_name} include directories: ${var}")
+endfunction()
+
+# Define the path to the test files directory
+set(UNIT_TESTS_DIR ${ROOT_DIR}/Tests)
+
+# Generate test executables
+gen_test(fft     ${UNIT_TESTS_DIR}/common/test_fft.cpp)
+gen_test(algorithms ${UNIT_TESTS_DIR}/common/test_algorithms.cpp)

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -4,11 +4,6 @@ project(tests CXX C)
 set(TESTS_DIR ${CMAKE_CURRENT_LIST_DIR})
 cmake_path(GET TESTS_DIR PARENT_PATH ROOT_DIR)
 
-message(STATUS "ROOT_DIR: ${ROOT_DIR}")
-message(STATUS "CMAKE_CURRENT_LIST_DIR: ${CMAKE_CURRENT_LIST_DIR}")
-message(STATUS "CMAKE_CURRENT_SOURCE_DIR: ${CMAKE_CURRENT_SOURCE_DIR}")
-message(STATUS "CRNT_DIR: ${CRNT_DIR}")
-
 # Check if the COVERAGE flag is set
 option(COVERAGE "Enable coverage flags" OFF)
 option(TEST_NUM "Enable test num" OFF)

--- a/Tests/Makefile
+++ b/Tests/Makefile
@@ -15,7 +15,6 @@ $(info BUILD_DIR: ${BUILD_DIR})
 
 CFLAGS := "-g -O0 -DDEBUG"
 CMAKE_FLAGS := -DCMAKE_C_COMPILER=${CC} -DCMAKE_CXX_COMPILER=${CC} -DCMAKE_C_FLAGS=${CFLAGS} -DCMAKE_CXX_FLAGS=${CFLAGS} -DCMAKE_BUILD_TYPE=Debug
-# cmake /home/user/Documents/work/mini_v2_node/Tests -DCMAKE_C_COMPILER=cc -DCMAKE_CXX_COMPILER=cc -DCMAKE_C_FLAGS="-g -O0 -DDEBUG" -DCMAKE_CXX_FLAGS="-g -O0 -DDEBUG" -DCMAKE_BUILD_TYPE=Debug
 
 all: test_common
 
@@ -27,7 +26,7 @@ create_build_dir:
 coverage: create_build_dir
 	cd ${BUILD_DIR} && cmake -DCOVERAGE=1 ${CRNT_DIR} && make
 	cd ${BUILD_DIR} && ./algorithms
-	cd ${BUILD_DIR} && ./ft
+	cd ${BUILD_DIR} && ./fft
 
 	echo "\n1. Algorithms:"
 	cd ${BUILD_DIR} && gcov ${BUILD_DIR}/CMakeFiles/algorithms.dir${REPO_DIR}/common/algorithms.cpp.gcda

--- a/Tests/Makefile
+++ b/Tests/Makefile
@@ -1,0 +1,42 @@
+# Copyright (c) 2023 Dmitry Ponomarev <ponomarevda96@gmail.com>
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+CRNT_DIR:=$(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
+TESTS_DIR:=$(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
+REPO_DIR := $(abspath $(dir $(lastword $(TESTS_DIR))))
+BUILD_DIR=${REPO_DIR}/build/Tests
+
+$(info CRNT_DIR: ${CRNT_DIR})
+$(info TESTS_DIR: ${TESTS_DIR})
+$(info REPO_DIR: ${REPO_DIR})
+$(info BUILD_DIR: ${BUILD_DIR})
+
+CFLAGS := "-g -O0 -DDEBUG"
+CMAKE_FLAGS := -DCMAKE_C_COMPILER=${CC} -DCMAKE_CXX_COMPILER=${CC} -DCMAKE_C_FLAGS=${CFLAGS} -DCMAKE_CXX_FLAGS=${CFLAGS} -DCMAKE_BUILD_TYPE=Debug
+# cmake /home/user/Documents/work/mini_v2_node/Tests -DCMAKE_C_COMPILER=cc -DCMAKE_CXX_COMPILER=cc -DCMAKE_C_FLAGS="-g -O0 -DDEBUG" -DCMAKE_CXX_FLAGS="-g -O0 -DDEBUG" -DCMAKE_BUILD_TYPE=Debug
+
+all: test_common
+
+test_common: fft algorithms
+
+create_build_dir:
+	mkdir -p ${BUILD_DIR}
+
+coverage: create_build_dir
+	cd ${BUILD_DIR} && cmake -DCOVERAGE=1 ${CRNT_DIR} && make
+	cd ${BUILD_DIR} && ./algorithms
+	cd ${BUILD_DIR} && ./ft
+
+	echo "\n1. Algorithms:"
+	cd ${BUILD_DIR} && gcov ${BUILD_DIR}/CMakeFiles/algorithms.dir${REPO_DIR}/common/algorithms.cpp.gcda
+
+	echo "\n2. FFT:"
+	cd ${BUILD_DIR} && gcov ${BUILD_DIR}/CMakeFiles/fft.dir${REPO_DIR}/common/fft.c.gcda
+
+algorithms: create_build_dir
+	cd ${BUILD_DIR} && cmake -S ${CRNT_DIR} && make && ./algorithms
+
+fft: create_build_dir
+	cd ${BUILD_DIR} && cmake ${CRNT_DIR} ${CMAKE_FLAGS} && make && ./fft

--- a/Tests/common/test_fft.cpp
+++ b/Tests/common/test_fft.cpp
@@ -1,0 +1,442 @@
+/**
+ * This program is free software under the GNU General Public License v3.
+ * See <https://www.gnu.org/licenses/> for details.
+ * Author: Anastasiia Stepanova <asiiapine@gmail.com>
+ */
+
+#include <gtest/gtest.h>
+#include <cmath>  // For std::fabs
+#include <algorithm>  // For std::clamp
+#include <tuple>  // for tuple
+
+#include "FFT.hpp"
+
+static constexpr auto ABS_ERR = 0.1f;
+unsigned int seed = 1;
+
+template <typename T>
+auto IsInRange(T lo, T hi) {
+    return AllOf(Ge((lo)), Le((hi)));
+}
+::testing::AssertionResult IsBetweenInclusive(int val, int a, int b)
+{
+    if((val >= a) && (val <= b))
+        return ::testing::AssertionSuccess();
+    else
+        return ::testing::AssertionFailure()
+               << val << " is outside the range " << a << " to " << b;
+}
+
+struct InitFFTParamType   {
+    float sample_rate_hz;
+    uint8_t n_axes;
+    uint16_t window_size;
+};
+
+template <typename T>
+struct InitParamType   {
+    InitFFTParamType fft_parameters;
+    T signals_parameters;
+};
+
+struct InitOneSignParamType   {
+    float sample_rate_hz = 0;
+    float freq_hz = 0;
+    float amplitude = 0;
+};
+
+struct InitMultiSignalsParamType   {
+    uint16_t sample_rate_hz;
+    uint8_t n_signals;
+    uint16_t max_freq;
+};
+
+struct InitParamOneSignalWithRes {
+    InitParamType<InitOneSignParamType> parameters;
+    bool result;
+};
+
+struct InitParamMultiSignalWithRes {
+    InitParamType<InitMultiSignalsParamType> parameters;
+    bool result;
+};
+
+InitParamOneSignalWithRes OneSignalTestParams[13] = {
+    // 0
+    {{InitFFTParamType{      .sample_rate_hz = 100,   .n_axes   = 1,    .window_size  = 24},
+      InitOneSignParamType{  .sample_rate_hz = 100,   .freq_hz  = 3,    .amplitude    = 1}},
+      true},
+    // 1
+    {{InitFFTParamType{      .sample_rate_hz = 1000, .n_axes   = 1,    .window_size  = 1000},
+      InitOneSignParamType{  .sample_rate_hz = 1000, .freq_hz  = 100,  .amplitude    = 10}},
+      true},
+    // 2
+    {{InitFFTParamType{      .sample_rate_hz = 1000, .n_axes   = 1,    .window_size  = 100},
+      InitOneSignParamType{  .sample_rate_hz = 1000, .freq_hz  = 5,    .amplitude    = 10}},
+      true},
+    // 3
+    {{InitFFTParamType{      .sample_rate_hz = 2000, .n_axes   = 1,    .window_size  = 600},
+      InitOneSignParamType{  .sample_rate_hz = 2000, .freq_hz  = 100,  .amplitude    = 10}},
+      true},
+    // 4
+    {{InitFFTParamType{      .sample_rate_hz = 2000, .n_axes   = 1,    .window_size  = 2000},
+      InitOneSignParamType{  .sample_rate_hz = 2000, .freq_hz  = 100,  .amplitude    = 10}},
+      true},
+    // 5
+    {{InitFFTParamType{      .sample_rate_hz = 1024, .n_axes   = 1,    .window_size  = 1024},
+      InitOneSignParamType{  .sample_rate_hz = 1024, .freq_hz  = 100,  .amplitude    = 1}},
+      true},
+    // 6
+    {{InitFFTParamType{      .sample_rate_hz = 256, .n_axes   = 1,    .window_size  = 256},
+      InitOneSignParamType{  .sample_rate_hz = 256, .freq_hz  = 100,  .amplitude    = 1}},
+      true},
+    // // 7
+    {{InitFFTParamType{      .sample_rate_hz = 1000, .n_axes   = 1,    .window_size  = 500},
+      InitOneSignParamType{  .sample_rate_hz = 1000, .freq_hz  = 100,  .amplitude    = 1}},
+      true},
+    // 8
+    {{InitFFTParamType{     .sample_rate_hz = 300,  .n_axes   = 1,    .window_size  = 600},
+      InitOneSignParamType{ .sample_rate_hz = 300,  .freq_hz  = 100,  .amplitude    = 1}},
+      true},
+    // 9
+    {{InitFFTParamType{    .sample_rate_hz = 300,  .n_axes   = 1,    .window_size  = 600},
+      InitOneSignParamType{ .sample_rate_hz = 1000, .freq_hz  = 100,  .amplitude    = 1}}, false},
+    // 10
+    {{InitFFTParamType{    .sample_rate_hz = 200,  .n_axes   = 1,    .window_size  = 400},
+      InitOneSignParamType{ .sample_rate_hz = 1000, .freq_hz  = 2000, .amplitude    = 1}}, false},
+    // 11
+    {{InitFFTParamType{    .sample_rate_hz = 1000, .n_axes   = 1,    .window_size  = 1024},
+      InitOneSignParamType{ .sample_rate_hz = 1000, .freq_hz  = 1000, .amplitude    = 1}}, false},
+    // 12
+    {{InitFFTParamType{    .sample_rate_hz = 1000, .n_axes   = 1,    .window_size  = 1024},
+      InitOneSignParamType{.sample_rate_hz  = 10,    .freq_hz = 5,    .amplitude    = 1}}, false},
+};
+
+InitParamMultiSignalWithRes MultiSignalTestParams[8] = {
+    // 0
+    {{InitFFTParamType{          .sample_rate_hz = 24,   .n_axes    = 1,   .window_size = 24},
+      InitMultiSignalsParamType{ .sample_rate_hz = 24,   .n_signals = 2,   .max_freq    = 12}},
+      true},
+    // 1
+    {{InitFFTParamType{          .sample_rate_hz = 1000, .n_axes    = 1,   .window_size = 1000},
+      InitMultiSignalsParamType{ .sample_rate_hz = 1000, .n_signals = 5,   .max_freq    = 500}},
+      true},
+    // 2
+    {{InitFFTParamType{          .sample_rate_hz = 1000, .n_axes    = 1,   .window_size = 100},
+      InitMultiSignalsParamType{ .sample_rate_hz = 1000, .n_signals = 4,   .max_freq    = 50}},
+      true},
+    // 3
+    {{InitFFTParamType{          .sample_rate_hz = 2000, .n_axes    = 1,   .window_size = 600},
+      InitMultiSignalsParamType{ .sample_rate_hz = 2000, .n_signals = 10,   .max_freq    = 300}},
+      true},
+    // 4
+    {{InitFFTParamType{          .sample_rate_hz = 2000, .n_axes    = 1,   .window_size = 2000},
+      InitMultiSignalsParamType{ .sample_rate_hz = 2000, .n_signals = 12,   .max_freq    = 1000}},
+      true},
+    // 5
+    {{InitFFTParamType{          .sample_rate_hz = 1024, .n_axes    = 1,   .window_size = 1024},
+      InitMultiSignalsParamType{ .sample_rate_hz = 1024, .n_signals = 15,   .max_freq    = 511}},
+      true},
+    // 6
+    {{InitFFTParamType{          .sample_rate_hz = 256, .n_axes     = 1,   .window_size = 256},
+      InitMultiSignalsParamType{ .sample_rate_hz = 256, .n_signals  = 13,   .max_freq    = 128}},
+      true},
+    // 7
+    {{InitFFTParamType{          .sample_rate_hz = 512, .n_axes     = 1,   .window_size = 512},
+      InitMultiSignalsParamType{ .sample_rate_hz = 512, .n_signals  = 10,   .max_freq    = 256}},
+      true},
+};
+
+class SinSignalGenerator {
+public:
+    SinSignalGenerator(){}
+    explicit SinSignalGenerator(InitOneSignParamType signal_parameters) {
+        this->sample_rate_hz = signal_parameters.sample_rate_hz;
+        this->freq_hz = signal_parameters.freq_hz;
+        this->amplitude = signal_parameters.amplitude;
+        this->phase = 0;
+        this->secs = 0;
+    }
+    SinSignalGenerator(float sample_rate_hz, float freq_hz, float amplitude) {
+        this->sample_rate_hz = sample_rate_hz;
+        this->freq_hz = freq_hz;
+        this->amplitude = amplitude;
+        this->phase = 0;
+        this->secs = 0;
+    }
+    float get_next_sample() {
+        auto sin = sinf(2 * M_PI * freq_hz * secs + phase);
+        float sample = (float)amplitude * sin;
+        secs += 1 / sample_rate_hz;
+        return sample;
+    }
+    float freq_hz;
+    float amplitude;
+
+private:
+    float sample_rate_hz;
+    float phase;
+    float secs;
+};
+
+class MultiSignalsSinGenerator {
+public:
+    std::vector<SinSignalGenerator> signals_generator;
+    uint8_t n_signals;
+    std::vector<std::tuple<uint16_t, uint16_t>> dominant_sig;
+
+    void init() {
+        signals_generator.resize(n_signals);
+        uint16_t max_amplitude = 0;
+        for (int j = 0; j < n_signals; j++) {
+            uint16_t freq_hz = rand_r(&seed) % (max_freq - min_freq) + min_freq;
+            uint16_t amplitude = 1 + rand_r(&seed) % 100;
+            signals_generator[j] = SinSignalGenerator(sample_rate_hz, freq_hz, amplitude);
+            if (amplitude > max_amplitude) {
+                max_amplitude = amplitude;
+                dominant_sig.insert(dominant_sig.begin(), std::make_tuple(amplitude, freq_hz));
+            }
+        }
+        for (int j = 0; j < dominant_sig.size(); j++) {
+            printf("dominant freq: %d\n", std::get<1>(dominant_sig[j]));
+        }
+        // sort by amplitude value
+        std::sort(dominant_sig.begin(), dominant_sig.end());
+    }
+
+    MultiSignalsSinGenerator() {}
+
+    MultiSignalsSinGenerator(uint8_t n_signals, uint16_t sample_rate_hz, uint16_t max_freq) {
+        this->n_signals = n_signals;
+        this->sample_rate_hz = sample_rate_hz;
+        this->max_freq = max_freq;
+        init();
+    }
+
+    explicit MultiSignalsSinGenerator(InitMultiSignalsParamType parameters) {
+        this->n_signals = parameters.n_signals;
+        this->sample_rate_hz = parameters.sample_rate_hz;
+        this->max_freq = parameters.max_freq;
+        init();
+    }
+
+    float get_next_samples() {
+        float sample = 0;
+        for (int j = 0; j < n_signals; j++) {
+            sample +=signals_generator[j].get_next_sample();
+        }
+        return sample;
+    }
+
+private:
+    uint16_t max_freq;
+    uint16_t min_freq = 0;
+    uint16_t sample_rate_hz;
+};
+
+template<typename T, typename InitParamType>
+class TestFFTBase : public ::testing::Test {
+public:
+    /* data */
+    FFT fft;
+    std::vector<T> signals_generator;
+    InitFFTParamType fft_parameters;
+    std::vector<InitParamType> signals_parameters;
+    float abs_error;
+
+    void print_fft_parameters() {
+        // Print the FFT parameters
+        std::cout << "FFT Parameters: " << std::endl;
+        std::cout << "  Sample Rate (Hz): " << fft_parameters.sample_rate_hz << std::endl;
+        std::cout << "  Window Size: " << fft_parameters.window_size << std::endl;
+        std::cout << "  Number of Axes: " << static_cast<int>(fft_parameters.n_axes) << std::endl;
+    }
+
+    void init() {
+        fft.init(fft_parameters.window_size, fft_parameters.n_axes, fft_parameters.sample_rate_hz);
+        signals_generator.resize(fft_parameters.n_axes);
+        for (int i = 0; i < fft_parameters.n_axes; i++) {
+            auto signal_parameters = signals_parameters[i];
+            signals_generator[i] = T(signal_parameters);
+        }
+        abs_error = 10 * fft._resolution_hz;
+    }
+};
+
+class TestFFTOneSignalParametrized : public TestFFTBase<SinSignalGenerator,
+                                            InitOneSignParamType>,
+                        public testing::WithParamInterface<InitParamOneSignalWithRes> {
+public:
+    /* data */
+    bool result;
+
+    void print_signal_parameters() {
+                // Print the signal parameters
+        std::cout << "Signal Parameters: " << std::endl;
+        std::cout << "  Sample Rate (Hz): " << signals_parameters[0].sample_rate_hz
+                    << std::endl;
+        std::cout << "  Frequency (Hz): " << signals_parameters[0].freq_hz
+                    << std::endl;
+        std::cout << "  Amplitude: " << signals_parameters[0].amplitude
+                    << std::endl;
+    }
+    void SetUp() override {
+        auto parameters = GetParam();
+        InitParamType<InitOneSignParamType> init_parameters = parameters.parameters;
+        result = parameters.result;
+        fft_parameters = init_parameters.fft_parameters;
+        // expand signal_parameters to multiple axes if needed
+        signals_parameters.resize(fft_parameters.n_axes);
+        for (int i = 0; i < fft_parameters.n_axes; i++) {
+            signals_parameters[i] = init_parameters.signals_parameters;
+        }
+        print_signal_parameters();
+        print_fft_parameters();
+        init();
+    }
+};
+
+TEST_P(TestFFTOneSignalParametrized, CheckOnWindow) {
+    float input[fft_parameters.n_axes];
+    for (int i = 0; i < fft_parameters.window_size + 10; i++) {
+        for (int j = 0; j < fft_parameters.n_axes; j++) {
+            input[j] = signals_generator[j].get_next_sample();
+        }
+        fft.update(input);
+    }
+    for (int j = 0; j < fft_parameters.n_axes; j++) {
+        printf("AXIS: %d\n", j);
+        for (int i = 0; i < MAX_NUM_PEAKS; i++) {
+            printf("%d:\n freq:\t%f\n", i,
+                        fft.peak_frequencies[j][i]);
+            printf(" snr:\t%f\n", fft.peak_snr[j][i]);
+        }
+    }
+    printf("fft resolution: %f\n", fft._resolution_hz);
+    if (result) {
+        for (int i = 0; i < fft_parameters.n_axes; i++) {
+            EXPECT_NEAR(fft.peak_frequencies[i][0],
+                        signals_parameters[i].freq_hz, 10 * fft._resolution_hz);
+        }
+    } else {
+        for (int i = 0; i < fft_parameters.n_axes; i++) {
+            ASSERT_FALSE(IsBetweenInclusive(fft.peak_frequencies[i][0],
+                         signals_parameters[i].freq_hz - 10 * fft._resolution_hz,
+                         signals_parameters[i].freq_hz + 10 * fft._resolution_hz));
+        }
+    }
+}
+
+TEST_P(TestFFTOneSignalParametrized, CheckOnFewWindows) {
+    float input[fft_parameters.n_axes];
+    auto n_updates = (rand_r(&seed) % 8 + 2) * fft_parameters.window_size;
+    // auto n_updates = (2 + rand_r(&seed) % 10) * fft_parameters.window_size;
+    for (int i = 0; i < n_updates + 10; i++) {
+        for (int j = 0; j < fft_parameters.n_axes; j++) {
+            input[j] = signals_generator[j].get_next_sample();
+        }
+        fft.update(input);
+    }
+    if (result) {
+        for (int i = 0; i < fft_parameters.n_axes; i++) {
+            EXPECT_NEAR(fft.peak_frequencies[i][0],
+                        signals_generator[i].freq_hz, 10 * fft._resolution_hz);
+        }
+    } else {
+        for (int i = 0; i < fft_parameters.n_axes; i++) {
+            ASSERT_FALSE(IsBetweenInclusive(fft.peak_frequencies[i][0],
+                         signals_generator[i].freq_hz - 10 * fft._resolution_hz,
+                         signals_generator[i].freq_hz + 10 * fft._resolution_hz));
+        }
+    }
+}
+
+INSTANTIATE_TEST_SUITE_P(TestFFTOneSignalParametrized,
+                         TestFFTOneSignalParametrized,
+                         ::testing::ValuesIn(
+                             OneSignalTestParams)
+                         );
+
+
+class TestFFTOnMultiSignalsParametrized : public TestFFTBase<MultiSignalsSinGenerator,
+                                                 InitMultiSignalsParamType>,
+                public ::testing::WithParamInterface<InitParamMultiSignalWithRes> {
+public:
+    /* data */
+    bool result;
+    std::vector<float> input;
+    void print_signal_parameters() {
+                // Print the signal parameters
+        std::cout << "Signal Parameters: " << std::endl;
+        std::cout << "  Sample Rate (Hz): " << signals_parameters[0].sample_rate_hz
+                    << std::endl;
+        std::cout << "  Number of Signals: " << signals_parameters[0].n_signals
+                    << std::endl;
+        std::cout << "  Max Freq: " << signals_parameters[0].max_freq
+                    << std::endl;
+    }
+
+    void SetUp() override {
+        auto parameters = GetParam();
+        InitParamType<InitMultiSignalsParamType> init_parameters = parameters.parameters;
+        result = parameters.result;
+        fft_parameters = init_parameters.fft_parameters;
+        signals_parameters.resize(fft_parameters.n_axes);
+        input.resize(fft_parameters.n_axes);
+        for (int i = 0; i < fft_parameters.n_axes; i++) {
+            signals_parameters[i] = init_parameters.signals_parameters;
+        }
+        print_signal_parameters();
+        print_fft_parameters();
+        init();
+    }
+};
+
+TEST_P(TestFFTOnMultiSignalsParametrized, CheckOnWindow) {
+    for (int i = 0; i < fft_parameters.window_size + 10; i++) {
+        for (int j = 0; j < fft_parameters.n_axes; j++) {
+            input[j] = signals_generator[j].get_next_samples();
+        }
+        fft.update(input.data());
+    }
+    for (int axis = 0; axis < fft_parameters.n_axes; axis++) {
+        bool heat_peak;
+        auto signal_generator = signals_generator[axis];
+        auto n_dominants = signal_generator.dominant_sig.size();
+        auto n_signals = signal_generator.n_signals;
+        printf("abs error: %f\n", abs_error);
+        for (int peak_index = 0; peak_index < MAX_NUM_PEAKS; peak_index++) {
+            printf("peak index: %d\n", peak_index);
+            printf("fft peak freq: %f\n", fft.peak_frequencies[axis][peak_index]);
+            for (int j = 0; j < n_dominants; j++) {
+                auto dominant_freq = signal_generator.dominant_sig[j];
+                printf("dominant freq: %d\n", std::get<1>(dominant_freq));
+                if (IsBetweenInclusive(fft.peak_frequencies[axis][peak_index],
+                            std::get<1>(dominant_freq) - abs_error,
+                            std::get<1>(dominant_freq) + abs_error)) {
+                    heat_peak = true;
+                    break;
+                }
+            }
+            if (heat_peak) {
+                break;
+            }
+        }
+        if (result) {
+            EXPECT_TRUE(heat_peak);
+        } else {
+            ASSERT_FALSE(heat_peak);
+            }
+    }
+}
+
+INSTANTIATE_TEST_SUITE_P(TestFFTOnMultiSignalsParametrized,
+                         TestFFTOnMultiSignalsParametrized,
+                         ::testing::ValuesIn(
+                             MultiSignalTestParams)
+                         );
+
+int main(int argc, char** argv) {
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}

--- a/cmake/stm32g0b1.cmake
+++ b/cmake/stm32g0b1.cmake
@@ -6,7 +6,8 @@ set(CPU STM32G0B1xx)
 set(stm32cubeMxProjectPath ${ROOT_DIR}/Libs/mini-v3-ioc)
 FILE(GLOB ldFile ${stm32cubeMxProjectPath}/*_FLASH.ld)
 FILE(GLOB coreSources       ${stm32cubeMxProjectPath}/Core/Src/*)
-FILE(GLOB driversSources    ${stm32cubeMxProjectPath}/Drivers/*/*/*.c)
+FILE(GLOB driversSources    ${stm32cubeMxProjectPath}/Drivers/*/*/*.c
+                            ${stm32cubeMxProjectPath}/Drivers/*/*/*/*.c)
 FILE(GLOB startupFile       ${stm32cubeMxProjectPath}/*.s
                             ${stm32cubeMxProjectPath}/Core/Startup/*.s
 )


### PR DESCRIPTION
This PR adds rfft algorithm for both ubuntu version and stm32 version.
Real fft was borrowed from public libraries:
- for stm32 --- CMSIS-DSP
- for ubuntu fftw3 [installation script](https://gist.githubusercontent.com/AsiiaPine/89276529c5b13be04264f2fe8b4e6c4f/raw/1b98d131c13fd618458e6b61eec4d4a3ab29137d/install_fftw3.sh). The version is used for unit tests

### Firmware image size difference

<!-- We don't automatically evaluate the firmware size difference yet. Please, do it manually. -->

- dronecan_v2: ? -> ? (+?)
- dronecan_v3: ? -> ? (+?)
- cyphal_v2: ? -> ? (+?)
- cyphal_v3: ? -> ? (+?)

### Test coverage

- In SITL...
- With real device...
