### PR TITLE
upd params, add vibration estimation

### DIFF
--- a/Src/modules/imu/imu.hpp
+++ b/Src/modules/imu/imu.hpp
@@ -4,8 +4,8 @@
  * Author: Dmitry Ponomarev <ponomarevda96@gmail.com>
  */
 
-#ifndef SRC_MODULES_CANOPEN_HPP_
-#define SRC_MODULES_CANOPEN_HPP_
+#ifndef SRC_MODULES_IMU_HPP_
+#define SRC_MODULES_IMU_HPP_
 
 #include <numbers>
 #include "module.hpp"
@@ -18,20 +18,31 @@ extern "C" {
 
 class ImuModule : public Module {
 public:
-    ImuModule() : Module(10.0) {}
+    enum class Bitmask : uint8_t {
+        DISABLED                    = 0,
+        ENABLE_VIB_ESTIM            = 2,
+        ENABLE_FFT_ACC              = 4,
+        ENABLE_FFT_GYR              = 8,
+        ENABLE_ALL_BY_DEFAULT       = 15,
+    };
+    ImuModule() : Module(400.0, Protocol::DRONECAN) {}
     void init() override;
 
 protected:
     void spin_once() override;
     void update_params() override;
+    void get_vibration(std::array<float, 3> data);
+    void fft();
 
 private:
     DronecanPublisher<AhrsRawImu> pub;
     DronecanPublisher<MagneticFieldStrength2> mag;
     Mpu9250 imu;
+    float vibration = 0.0f;
     bool initialized{false};
     bool enabled{false};
-
+    uint8_t bitmask{0};
+    uint16_t pub_timeout_ms{0};
     static constexpr float raw_gyro_to_rad_per_second(int16_t raw_gyro) {
         return raw_gyro * std::numbers::pi_v<float> / 131.0f / 180.0f;
     }
@@ -45,4 +56,4 @@ private:
 }
 #endif
 
-#endif  // SRC_MODULES_CANOPEN_HPP_
+#endif  // SRC_MODULES_IMU_HPP_

--- a/Src/modules/imu/params.yaml
+++ b/Src/modules/imu/params.yaml
@@ -1,8 +1,23 @@
-imu.enable:
+imu.mode:
   type: Integer
-  note: Enable or disable IMU publisher.
-  enum: PARAM_IMU_ENABLE
+  note: 
+      "Bit mask to enable IMU features:
+    </br> Bit 1 - enable RawImu publisher,
+    </br> Bit 2 - enable vibration metric publishing to RawImu.integration_interval,
+    </br> Bit 3 - enable FFT acceleration publishing to RawImu.accelerometer_integral,
+    </br> Bit 4 - enable FFT acceleration publishing to RawImu.rate_gyro_integral,
+    </br> By default 15 that mean enable all publishers"
+  enum: PARAM_IMU_MODE_BITMASK
   flags: mutable
   default: 0
   min: 0
-  max: 1
+  max: 16
+
+imu.pub_frequency:
+  type: Integer
+  note: Frequency of IMU publisher [Hz].
+  enum: PARAM_IMU_PUB_FREQUENCY
+  flags: mutable
+  default: 1
+  min: 0
+  max: 400

--- a/docs/dronecan/README.md
+++ b/docs/dronecan/README.md
@@ -30,7 +30,8 @@ The node has the following registers:
 | pwm4.max                | PWM duration when setpoint is max (RawCommand is 8191 or Command is 1.0) |
 | pwm4.def                | PWM duration when setpoint is negative or there is no setpoint at all. |
 | pwm.cmd_type            | 0 means RawCommand, 1 means ArrayCommand, 2 is reserved for hardpoint.Command. |
-| imu.enable              | Enable or disable IMU publisher. |
+| imu.mode                | Bit mask to enable IMU features: </br> Bit 1 - enable RawImu publisher, </br> Bit 2 - enable vibration metric publishing to RawImu.integration_interval, </br> Bit 3 - enable FFT acceleration publishing to RawImu.accelerometer_integral, </br> Bit 4 - enable FFT acceleration publishing to RawImu.rate_gyro_integral, </br> By default 15 that mean enable all publishers |
+| imu.pub_frequency       | Frequency of IMU publisher [Hz]. |
 
 > This docs was automatically generated. Do not edit it manually.
 


### PR DESCRIPTION
This PR adds vibration estimation for imu module, refactors parameters for the module according to the [file](https://github.com/RaccoonlabDev/mini_v2_node/wiki/Vibrations), updates mini_v3_ioc lib

### Firmware image size difference

<!-- We don't automatically evaluate the firmware size difference yet. Please, do it manually. -->

- dronecan_v2: ? -> ? (+?)
- dronecan_v3: ? -> ? (+?)
- cyphal_v2: ? -> ? (+?)
- cyphal_v3: ? -> ? (+?)

### Test coverage
[x] With real device 
![image](https://github.com/user-attachments/assets/8b07ae0a-4d2c-4ca0-8488-76a41caef6d4)

