### PR TITLE
Fix circuit_id type from uint8_t to uint16_t

### DIFF
--- a/Src/modules/circuit_status/dronecan/circuit_status.cpp
+++ b/Src/modules/circuit_status/dronecan/circuit_status.cpp
@@ -37,7 +37,7 @@ void DronecanCircuitStatus::spin_once() {
 
     if (bitmask & static_cast<uint8_t>(Bitmask::ENABLE_5V_PUB)) {
         circuit_status.msg = {
-            .circuit_id = static_cast<uint8_t>(node_id * 10),
+            .circuit_id = static_cast<uint16_t>(node_id * 10),
             .voltage = CircuitPeriphery::voltage_5v(),
             .current = CircuitPeriphery::current(),
             .error_flags = static_cast<CircuitStatusErrorFlags_t>(error_flags),
@@ -47,7 +47,7 @@ void DronecanCircuitStatus::spin_once() {
 
     if (bitmask & static_cast<uint8_t>(Bitmask::ENABLE_VIN_PUB)) {
         circuit_status.msg = {
-            .circuit_id = static_cast<uint8_t>(node_id * 10 + 1),
+            .circuit_id = static_cast<uint16_t>(node_id * 10 + 1),
             .voltage = CircuitPeriphery::voltage_vin(),
             .current = CircuitPeriphery::current(),
             .error_flags = static_cast<CircuitStatusErrorFlags_t>(error_flags),

--- a/Src/modules/system/params.yaml
+++ b/Src/modules/system/params.yaml
@@ -4,8 +4,8 @@ uavcan.node.id:
   enum: PARAM_UAVCAN_NODE_ID
   flags: mutable
   default: 42
-  min: 0
-  max: 255
+  min: 1
+  max: 126
 
 uavcan.node.description:
   note: User/integrator-defined, human-readable description of this specific node.


### PR DESCRIPTION
This PR fixes circuit_id type from uint8_t to uint16_t

## Test coverage
- With real device:

### circuit_id before

![изображение](https://github.com/user-attachments/assets/7f2159b5-cfd9-4fcf-91c7-0b08cb9f09e5)

### circuit_id after

![изображение](https://github.com/user-attachments/assets/ed266caa-8f30-4521-937b-9d624462d3db)

