### PR TITLE
fix: makefile. Dronecan lib update

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -154,7 +154,7 @@ tests:
 	${ROOT_DIR}/scripts/tests.sh
 
 upload:
-	LATEST_TARGET=$$(ls -td ${BUILD_DIR}/release/*.bin | head -1) && ./scripts/flash.sh $$LATEST_TARGET
+	LATEST_TARGET=$$(ls -td ${NC_BUILD_DIR}/release/*.bin | head -1) && ./scripts/flash.sh $$LATEST_TARGET
 
 SOCKETCAN_URL:=https://gist.githubusercontent.com/PonomarevDA/6ecc8fc340e4c50619c1e5dfcedc37b2/raw/2db6d1626a9ada543602ff0a52b48fecb94e6e07/socketcan.sh
 SOCKETCAN_EXECUTABLE:=build/tools/socketcan-v1.0.2.sh
@@ -172,8 +172,8 @@ remove_slcan0: download_socketcan
 run: create_slcan0
 	LATEST_TARGET=$$(ls -td build/*/obj/node | head -1 | head -1) && $$LATEST_TARGET
 clean_releases:
-	-rm -fR ${BUILD_DIR}/release
+	-rm -fR ${NC_BUILD_DIR}/release
 clean:
-	-rm -fR ${BUILD_DIR}/*/obj
+	-rm -fR ${NC_BUILD_DIR}/*/obj
 distclean:
-	-rm -fR ${BUILD_DIR}/
+	-rm -fR ${NC_BUILD_DIR}/


### PR DESCRIPTION
This PR fixes makefile and updates Dronecan lib on lastests version
